### PR TITLE
Retarget to netstandard 2.0

### DIFF
--- a/LocalisationAnalyser.Tests/Helpers/IO/MockFile.cs
+++ b/LocalisationAnalyser.Tests/Helpers/IO/MockFile.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Threading;
-using System.Threading.Tasks;
 using LocalisationAnalyser.Abstractions.IO;
 
 namespace LocalisationAnalyser.Tests.Helpers.IO
@@ -16,6 +14,6 @@ namespace LocalisationAnalyser.Tests.Helpers.IO
             this.mockFs = mockFs;
         }
 
-        public Task<string> ReadAllTextAsync(string fullname, CancellationToken cancellationToken) => mockFs.File.ReadAllTextAsync(fullname, cancellationToken);
+        public string ReadAllText(string fullname) => mockFs.File.ReadAllText(fullname);
     }
 }

--- a/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
+++ b/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using LocalisationAnalyser.Abstractions.IO;
 using LocalisationAnalyser.Localisation;
@@ -31,7 +30,7 @@ namespace LocalisationAnalyser.Tests.Localisation
         public async Task ClassGeneratedForNoFile()
         {
             await setupLocalisation();
-            await checkResult(string.Empty);
+            checkResult(string.Empty);
         }
 
         [Fact]
@@ -64,7 +63,7 @@ namespace {test_namespace}
 
             await setupLocalisation(new LocalisationMember(prop_name, key_name, english_text));
 
-            await checkResult($@"
+            checkResult($@"
         /// <summary>
         /// ""{english_text}""
         /// </summary>
@@ -116,7 +115,7 @@ namespace {test_namespace}
 
             await setupLocalisation(new LocalisationMember(method_name, key_name, english_text, param1, param2, param3));
 
-            await checkResult($@"
+            checkResult($@"
         /// <summary>
         /// ""{english_text}""
         /// </summary>
@@ -202,7 +201,7 @@ namespace {test_namespace}
                     new LocalisationParameter("int", "i")));
 
             IFileInfo file = mockFs.FileInfo.FromFileName(test_file_name);
-            string initial = await mockFs.File.ReadAllTextAsync(file.FullName, CancellationToken.None);
+            string initial = mockFs.File.ReadAllText(file.FullName);
 
             // Read and re-save via LocalisationFile.
             LocalisationFile localisation;
@@ -211,7 +210,7 @@ namespace {test_namespace}
             using (var stream = file.OpenWrite())
                 await localisation.WriteAsync(stream, workspace);
 
-            string updated = await mockFs.File.ReadAllTextAsync(file.FullName, CancellationToken.None);
+            string updated = mockFs.File.ReadAllText(file.FullName);
             Assert.Equal(initial, updated);
         }
 
@@ -228,7 +227,7 @@ namespace {test_namespace}
                 await new LocalisationFile(test_namespace, test_class_name, test_class_name, members).WriteAsync(stream, workspace);
         }
 
-        private async Task checkResult(string inner)
+        private void checkResult(string inner)
         {
             var sb = new StringBuilder();
 
@@ -249,7 +248,7 @@ namespace {test_namespace}
     }
 }");
 
-            Assert.Equal(sb.ToString().Trim(), await mockFs.File.ReadAllTextAsync(test_file_name, CancellationToken.None));
+            Assert.Equal(sb.ToString().Trim(), mockFs.File.ReadAllText(test_file_name));
         }
     }
 }

--- a/LocalisationAnalyser/Abstractions/IO/Default/DefaultFile.cs
+++ b/LocalisationAnalyser/Abstractions/IO/Default/DefaultFile.cs
@@ -2,13 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace LocalisationAnalyser.Abstractions.IO.Default
 {
     internal class DefaultFile : IFile
     {
-        public Task<string> ReadAllTextAsync(string fullname, CancellationToken cancellationToken) => File.ReadAllTextAsync(fullname, cancellationToken);
+        public string ReadAllText(string fullname) => File.ReadAllText(fullname);
     }
 }

--- a/LocalisationAnalyser/Abstractions/IO/IFile.cs
+++ b/LocalisationAnalyser/Abstractions/IO/IFile.cs
@@ -1,13 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace LocalisationAnalyser.Abstractions.IO
 {
     internal interface IFile
     {
-        Task<string> ReadAllTextAsync(string fullname, CancellationToken cancellationToken);
+        string ReadAllText(string fullname);
     }
 }

--- a/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
@@ -200,7 +200,7 @@ namespace LocalisationAnalyser.CodeFixes
                 {
                     var classDocument = project.AddDocument(
                         fileSystem.Path.GetFileName(file.FullName),
-                        await file.FileSystem.File.ReadAllTextAsync(file.FullName, cancellationToken),
+                        file.FileSystem.File.ReadAllText(file.FullName),
                         Enumerable.Empty<string>(),
                         file.FullName);
 
@@ -295,7 +295,7 @@ namespace LocalisationAnalyser.CodeFixes
         private static string createMemberName(LocalisationFile localisation, string englishText)
         {
             var basePropertyName = new string(englishText.Where(char.IsLetter).Take(10).ToArray());
-            basePropertyName = char.ToUpperInvariant(basePropertyName[0]) + basePropertyName[1..];
+            basePropertyName = char.ToUpperInvariant(basePropertyName[0]) + basePropertyName.Substring(1);
 
             var finalPropertyName = basePropertyName;
             int propertyNameSuffix = 0;

--- a/LocalisationAnalyser/Localisation/LocalisationFile.cs
+++ b/LocalisationAnalyser/Localisation/LocalisationFile.cs
@@ -88,7 +88,7 @@ namespace LocalisationAnalyser.Localisation
                 if (string.IsNullOrEmpty(walker.Prefix))
                     throw new MalformedLocalisationException("The localisation file contains no prefix identifier");
 
-                return new LocalisationFile(walker.Namespace, walker.Name, walker.Prefix.Replace($"{walker.Namespace}.", string.Empty), walker.Members.ToArray());
+                return new LocalisationFile(walker.Namespace!, walker.Name!, walker.Prefix!.Replace($"{walker.Namespace}.", string.Empty), walker.Members.ToArray());
             }
         }
 
@@ -109,6 +109,16 @@ namespace LocalisationAnalyser.Localisation
             return Equals((LocalisationFile)obj);
         }
 
-        public override int GetHashCode() => HashCode.Combine(Namespace, Name, Prefix, Members);
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Namespace.GetHashCode();
+                hashCode = (hashCode * 397) ^ Name.GetHashCode();
+                hashCode = (hashCode * 397) ^ Prefix.GetHashCode();
+                hashCode = (hashCode * 397) ^ Members.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 }

--- a/LocalisationAnalyser/Localisation/LocalisationFile_Walker.cs
+++ b/LocalisationAnalyser/Localisation/LocalisationFile_Walker.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -91,14 +90,14 @@ namespace LocalisationAnalyser.Localisation
                 if (!tryAnalyseMemberDefinition(node, out var name, out var parameters, out var body))
                     return;
 
-                if (!tryAnalyseMemberBody(body, out var key, out var englishText))
+                if (!tryAnalyseMemberBody(body!, out var key, out var englishText))
                     return;
 
                 Members.Add(new LocalisationMember(name, key, englishText, parameters));
             }
 
             private bool tryAnalyseMemberDefinition(MemberDeclarationSyntax member, out string name, out LocalisationParameter[] parameters,
-                                                    [NotNullWhen(true)] out ArrowExpressionClauseSyntax? body)
+                                                    out ArrowExpressionClauseSyntax? body)
             {
                 name = string.Empty;
                 parameters = Array.Empty<LocalisationParameter>();

--- a/LocalisationAnalyser/Localisation/LocalisationMember.cs
+++ b/LocalisationAnalyser/Localisation/LocalisationMember.cs
@@ -63,6 +63,16 @@ namespace LocalisationAnalyser.Localisation
             return Equals((LocalisationMember)obj);
         }
 
-        public override int GetHashCode() => HashCode.Combine(Name, Key, EnglishText, Parameters);
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Name.GetHashCode();
+                hashCode = (hashCode * 397) ^ Key.GetHashCode();
+                hashCode = (hashCode * 397) ^ EnglishText.GetHashCode();
+                hashCode = (hashCode * 397) ^ Parameters.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 }

--- a/LocalisationAnalyser/Localisation/LocalisationParameter.cs
+++ b/LocalisationAnalyser/Localisation/LocalisationParameter.cs
@@ -48,6 +48,12 @@ namespace LocalisationAnalyser.Localisation
             return Equals((LocalisationParameter)obj);
         }
 
-        public override int GetHashCode() => HashCode.Combine(Type, Name);
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Type.GetHashCode() * 397) ^ Name.GetHashCode();
+            }
+        }
     }
 }

--- a/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
+++ b/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
@@ -71,8 +71,10 @@ namespace LocalisationAnalyser.Localisation
                     Formatter.Format(paramList, workspace).ToFullString(),
                     member.Key,
                     convertToVerbatim(member.EnglishText),
-                    Formatter.Format(argList, workspace).ToFullString()[1..^1], // The entire string minus the parens
+                    trimParens(Formatter.Format(argList, workspace).ToFullString()), // The entire string minus the parens
                     member.EnglishText))!; // Todo: Improve xmldoc
+
+            static string trimParens(string input) => input.Substring(1, input.Length - 2);
         }
 
         /// <summary>

--- a/LocalisationAnalyser/LocalisationAnalyser.csproj
+++ b/LocalisationAnalyser/LocalisationAnalyser.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>9</LangVersion>
 


### PR DESCRIPTION
MSBuild.exe doesn't seem to like netstandard2.1... I'm just following this: https://github.com/dotnet/samples/tree/main/csharp/roslyn-sdk/Tutorials/MakeConst and it seems to work.