### PR TITLE
Add tool for .php -> .resx/.cs conversion

### DIFF
--- a/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
+++ b/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
@@ -214,6 +214,25 @@ namespace {test_namespace}
             Assert.Equal(initial, updated);
         }
 
+        [Fact]
+        public async Task ReservedKeywordIsPrefixed()
+        {
+            const string method_name = "TestMethod";
+            const string key_name = "TestKey";
+            const string english_text = "TestEnglish{0}{1}{2}";
+
+            var param1 = new LocalisationParameter("int", "new");
+
+            await setupLocalisation(new LocalisationMember(method_name, key_name, english_text, param1));
+
+            checkResult($@"
+        /// <summary>
+        /// ""{english_text}""
+        /// </summary>
+        public static LocalisableString {method_name}({param1.Type} @{param1.Name}) => new TranslatableString(getKey(@""{key_name}""), @""{english_text}"", @{param1.Name});
+");
+        }
+
         private async Task<LocalisationFile> setupFile(string contents)
         {
             mockFs.AddFile(test_file_name, contents);

--- a/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
+++ b/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
@@ -233,6 +233,41 @@ namespace {test_namespace}
 ");
         }
 
+        [Fact]
+        public async Task MultiLineEnglishTextGeneratesMultipleXmlDocLines()
+        {
+            const string prop_name = "TestProperty";
+            const string key_name = "TestKey";
+            const string english_text = "Line1\nLine2";
+
+            await setupLocalisation(new LocalisationMember(prop_name, key_name, english_text));
+
+            checkResult($@"
+        /// <summary>
+        /// ""Line1
+        /// Line2""
+        /// </summary>
+        public static LocalisableString {prop_name} => new TranslatableString(getKey(@""{key_name}""), @""{english_text}"");
+");
+        }
+
+        [Fact]
+        public async Task EnglishStringIsHtmlEncoded()
+        {
+            const string prop_name = "TestProperty";
+            const string key_name = "TestKey";
+            const string english_text = "hello & greetings";
+
+            await setupLocalisation(new LocalisationMember(prop_name, key_name, english_text));
+
+            checkResult($@"
+        /// <summary>
+        /// ""hello &amp; greetings""
+        /// </summary>
+        public static LocalisableString {prop_name} => new TranslatableString(getKey(@""{key_name}""), @""{english_text}"");
+");
+        }
+
         private async Task<LocalisationFile> setupFile(string contents)
         {
             mockFs.AddFile(test_file_name, contents);

--- a/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
+++ b/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
@@ -244,8 +244,7 @@ namespace {test_namespace}
 
             checkResult($@"
         /// <summary>
-        /// ""Line1
-        /// Line2""
+        /// ""Line1" + "\n" + $@"        /// Line2""
         /// </summary>
         public static LocalisableString {prop_name} => new TranslatableString(getKey(@""{key_name}""), @""{english_text}"");
 ");

--- a/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
+++ b/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
@@ -244,7 +244,8 @@ namespace {test_namespace}
 
             checkResult($@"
         /// <summary>
-        /// ""Line1" + "\n" + $@"        /// Line2""
+        /// ""Line1
+        /// Line2""
         /// </summary>
         public static LocalisableString {prop_name} => new TranslatableString(getKey(@""{key_name}""), @""{english_text}"");
 ");

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/InterpolatedStringWithQuotes/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/InterpolatedStringWithQuotes/Fixed/Localisation/ProgramStrings.txt
@@ -10,7 +10,7 @@ namespace TestProject.Localisation
         private const string prefix = @"TestProject.Localisation.Program";
 
         /// <summary>
-        /// "Folder "{0}" not available in the target osu!stable installation to import."
+        /// "Folder &quot;{0}&quot; not available in the target osu!stable installation to import."
         /// </summary>
         public static LocalisableString Foldernota(string fullPath) => new TranslatableString(getKey(@"foldernota"), @"Folder ""{0}"" not available in the target osu!stable installation to import.", fullPath);
 

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/VerbatimString/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/VerbatimString/Fixed/Localisation/ProgramStrings.txt
@@ -10,7 +10,7 @@ namespace TestProject.Localisation
         private const string prefix = @"TestProject.Localisation.Program";
 
         /// <summary>
-        /// "this is an "escaped" string"
+        /// "this is an &quot;escaped&quot; string"
         /// </summary>
         public static LocalisableString Thisisanes => new TranslatableString(getKey(@"thisisanes"), @"this is an ""escaped"" string");
 

--- a/LocalisationAnalyser.Tools.Tests/LocalisationAnalyser.Tools.Tests.csproj
+++ b/LocalisationAnalyser.Tools.Tests/LocalisationAnalyser.Tools.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+        <TargetFramework>net5.0</TargetFramework>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\LocalisationAnalyser.Tools\LocalisationAnalyser.Tools.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    </ItemGroup>
+
+</Project>

--- a/LocalisationAnalyser.Tools.Tests/PhpArrayElementSyntaxNodeTest.cs
+++ b/LocalisationAnalyser.Tools.Tests/PhpArrayElementSyntaxNodeTest.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using LocalisationAnalyser.Tools.Php;
+using Xunit;
+
+namespace LocalisationAnalyser.Tools.Tests
+{
+    public class PhpArrayElementSyntaxNodeTest
+    {
+        [Theory]
+        [InlineData("'Key' => 'Value'", "Key", "Value")]
+        [InlineData("'Key' => 'Value',", "Key", "Value")]
+        public void TestBasicElement(string input, string expectedKey, string expectedValue)
+        {
+            var syntaxNode = PhpArrayElementSyntaxNode.Parse(new PhpTokeniser(input));
+
+            Assert.Equal(expectedKey, syntaxNode.Key.Text);
+            Assert.IsType<PhpStringLiteralSyntaxNode>(syntaxNode.Value);
+            Assert.Equal(expectedValue, ((PhpStringLiteralSyntaxNode)syntaxNode.Value).Text);
+        }
+
+        [Fact]
+        public void TestArrayElement()
+        {
+            var syntaxNode = PhpArrayElementSyntaxNode.Parse(new PhpTokeniser(@"
+'Key' => [
+    'Key1' => 'Value1'
+]"));
+
+            Assert.Equal("Key", syntaxNode.Key.Text);
+            Assert.IsType<PhpArraySyntaxNode>(syntaxNode.Value);
+
+            var nestedArray = (PhpArraySyntaxNode)syntaxNode.Value;
+            Assert.Single(nestedArray.Elements);
+            Assert.Equal("Key1", nestedArray.Elements[0].Key.Text);
+            Assert.Equal("Value1", ((PhpStringLiteralSyntaxNode)nestedArray.Elements[0].Value).Text);
+        }
+
+        [Theory]
+        [InlineData("1 => 'Value'")]
+        [InlineData("'Key' => 1")]
+        [InlineData("'Key' : 'Value'")]
+        [InlineData("'Key' 'Value'")]
+        [InlineData("'Key'")]
+        public void TestInvalidElement(string input)
+        {
+            Assert.ThrowsAny<Exception>(() => PhpArrayElementSyntaxNode.Parse(new PhpTokeniser(input)));
+        }
+    }
+}

--- a/LocalisationAnalyser.Tools.Tests/PhpArraySyntaxNodeTest.cs
+++ b/LocalisationAnalyser.Tools.Tests/PhpArraySyntaxNodeTest.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using LocalisationAnalyser.Tools.Php;
+using Xunit;
+
+namespace LocalisationAnalyser.Tools.Tests
+{
+    public class PhpArraySyntaxNodeTest
+    {
+        [Fact]
+        public void TestEmptyArray()
+        {
+            var array = PhpArraySyntaxNode.Parse(new PhpTokeniser("[]"));
+            Assert.Empty(array.Elements);
+        }
+
+        [Fact]
+        public void TestSingleElement()
+        {
+            var array = PhpArraySyntaxNode.Parse(new PhpTokeniser(@"
+[
+    'Key' => 'Value',
+]"));
+
+            Assert.Single(array.Elements);
+            Assert.Equal("Key", array.Elements[0].Key.Text);
+            Assert.Equal("Value", ((PhpStringLiteralSyntaxNode)array.Elements[0].Value).Text);
+        }
+
+        [Fact]
+        public void TestMultipleElements()
+        {
+            var array = PhpArraySyntaxNode.Parse(new PhpTokeniser(@"
+[
+    'Key1' => 'Value1',
+    'Key2' => 'Value2',
+]"));
+
+            Assert.Equal(2, array.Elements.Length);
+            Assert.Equal("Key1", array.Elements[0].Key.Text);
+            Assert.Equal("Value1", ((PhpStringLiteralSyntaxNode)array.Elements[0].Value).Text);
+            Assert.Equal("Key2", array.Elements[1].Key.Text);
+            Assert.Equal("Value2", ((PhpStringLiteralSyntaxNode)array.Elements[1].Value).Text);
+        }
+
+        [Fact]
+        public void TestNestedArray()
+        {
+            var array = PhpArraySyntaxNode.Parse(new PhpTokeniser(@"
+[
+    'Key1' => 'Value1',
+    'Key2' => [
+        'Key3' => 'Value3'
+    ],
+]"));
+
+            Assert.Equal(2, array.Elements.Length);
+            Assert.Equal("Key1", array.Elements[0].Key.Text);
+            Assert.Equal("Key2", array.Elements[1].Key.Text);
+
+            var nestedArray = (PhpArraySyntaxNode)array.Elements[1].Value;
+            Assert.Single(nestedArray.Elements);
+            Assert.Equal("Key3", nestedArray.Elements[0].Key.Text);
+            Assert.Equal("Value3", ((PhpStringLiteralSyntaxNode)nestedArray.Elements[0].Value).Text);
+        }
+    }
+}

--- a/LocalisationAnalyser.Tools.Tests/PhpStringLiteralSyntaxNodeTest.cs
+++ b/LocalisationAnalyser.Tools.Tests/PhpStringLiteralSyntaxNodeTest.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using LocalisationAnalyser.Tools.Php;
+using Xunit;
+
+namespace LocalisationAnalyser.Tools.Tests
+{
+    public class PhpStringLiteralSyntaxNodeTest
+    {
+        [Theory]
+        [InlineData("''")]
+        [InlineData("\"\"")]
+        public void TestEmptyString(string input)
+        {
+            Assert.Equal(string.Empty, parse(input));
+        }
+
+        [Theory]
+        [InlineData("1", "'1'")]
+        [InlineData("1", "\"1\"")]
+        [InlineData("a", "'a'")]
+        [InlineData("a", "\"a\"")]
+        [InlineData("hello world", "'hello world'")]
+        [InlineData("hello world", "\"hello world\"")]
+        [InlineData("😊😊", "'😊😊'")]
+        [InlineData("😊😊", "\"😊😊\"")]
+        [InlineData("hello\nworld", "'hello\nworld'")]
+        [InlineData("hello\nworld", "\"hello\nworld\"")]
+        public void TestBasicString(string expected, string input)
+        {
+            Assert.Equal(expected, parse(input));
+        }
+
+        [Theory]
+        [InlineData(":username's data", "':username\\'s data'")]
+        [InlineData(":username's data", "\":username\\'s data\"")]
+        [InlineData("\"escaped\" quotes", "\"\\\"escaped\\\" quotes\"")]
+        public void TestEscapedString(string expected, string input)
+        {
+            Assert.Equal(expected, parse(input));
+        }
+
+        private string parse(string input) => PhpStringLiteralSyntaxNode.Parse(new PhpTokeniser(input)).Text;
+    }
+}

--- a/LocalisationAnalyser.Tools.Tests/PhpTokeniserTest.cs
+++ b/LocalisationAnalyser.Tools.Tests/PhpTokeniserTest.cs
@@ -51,6 +51,7 @@ $");
  * BLOCK COMMENT!!
  */
 /**/
+
 $");
 
             tokeniser.SkipWhitespace();

--- a/LocalisationAnalyser.Tools.Tests/PhpTokeniserTest.cs
+++ b/LocalisationAnalyser.Tools.Tests/PhpTokeniserTest.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using LocalisationAnalyser.Tools.Php;
+using Xunit;
+
+namespace LocalisationAnalyser.Tools.Tests
+{
+    public class PhpTokeniserTest
+    {
+        [Fact]
+        public void TestSkipSpaces()
+        {
+            var tokeniser = new PhpTokeniser("       $");
+            tokeniser.SkipWhitespace();
+
+            Assert.Equal('$', tokeniser.GetTrivia());
+        }
+
+        [Fact]
+        public void TestSkipNewLine()
+        {
+            var tokeniser = new PhpTokeniser("\n\n\n \n   $");
+            tokeniser.SkipWhitespace();
+
+            Assert.Equal('$', tokeniser.GetTrivia());
+        }
+
+        [Fact]
+        public void TestSkipLineComment()
+        {
+            var tokeniser = new PhpTokeniser(@"
+//
+// line 1
+// line 2
+// // //
+
+$");
+
+            tokeniser.SkipWhitespace();
+
+            Assert.Equal('$', tokeniser.GetTrivia());
+        }
+
+        [Fact]
+        public void TestSkipBlockComment()
+        {
+            var tokeniser = new PhpTokeniser(@"
+/**
+ * This is a
+ * BLOCK COMMENT!!
+ */
+/**/
+$");
+
+            tokeniser.SkipWhitespace();
+
+            Assert.Equal('$', tokeniser.GetTrivia());
+        }
+    }
+}

--- a/LocalisationAnalyser.Tools/LocalisationAnalyser.Tools.csproj
+++ b/LocalisationAnalyser.Tools/LocalisationAnalyser.Tools.csproj
@@ -25,6 +25,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Humanizer.Core" Version="2.10.1" />
         <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.3.1" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />

--- a/LocalisationAnalyser.Tools/Php/PhpArrayElementSyntaxNode.cs
+++ b/LocalisationAnalyser.Tools/Php/PhpArrayElementSyntaxNode.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace LocalisationAnalyser.Tools.Php
+{
+    /// <summary>
+    /// A PHP syntax node for an element of a <see cref="PhpArraySyntaxNode"/>.
+    /// </summary>
+    public class PhpArrayElementSyntaxNode : PhpSyntaxNode
+    {
+        public readonly PhpStringLiteralSyntaxNode Key;
+        public readonly PhpSyntaxNode Value;
+
+        public PhpArrayElementSyntaxNode(PhpStringLiteralSyntaxNode key, PhpSyntaxNode value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        public static PhpArrayElementSyntaxNode Parse(PhpTokeniser tokeniser)
+        {
+            tokeniser.SkipWhitespace();
+
+            PhpStringLiteralSyntaxNode key = tokeniser.GetTrivia() switch
+            {
+                '\'' => PhpStringLiteralSyntaxNode.Parse(tokeniser),
+                '"' => PhpStringLiteralSyntaxNode.Parse(tokeniser),
+                _ => throw tokeniser.ConstructError($"Invalid array value identifier ({tokeniser.GetTrivia()}).")
+            };
+
+            tokeniser.SkipWhitespace();
+            tokeniser.SkipPattern(new[] { '=', '>' });
+            tokeniser.SkipWhitespace();
+
+            PhpSyntaxNode value = tokeniser.GetTrivia() switch
+            {
+                '\'' => PhpStringLiteralSyntaxNode.Parse(tokeniser),
+                '"' => PhpStringLiteralSyntaxNode.Parse(tokeniser),
+                '[' => PhpArraySyntaxNode.Parse(tokeniser),
+                _ => throw tokeniser.ConstructError($"Invalid array value identifier ({tokeniser.GetTrivia()}).")
+            };
+
+            tokeniser.SkipWhitespace();
+
+            // Skip trailing trivia for this element.
+            if (tokeniser.TryGetTrivia(out var trivia) && trivia == ',')
+                tokeniser.Advance();
+            tokeniser.SkipWhitespace();
+
+            return new PhpArrayElementSyntaxNode(key, value);
+        }
+    }
+}

--- a/LocalisationAnalyser.Tools/Php/PhpArraySyntaxNode.cs
+++ b/LocalisationAnalyser.Tools/Php/PhpArraySyntaxNode.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Immutable;
+
+namespace LocalisationAnalyser.Tools.Php
+{
+    /// <summary>
+    /// A PHP syntax node for an array.
+    /// </summary>
+    public class PhpArraySyntaxNode : PhpSyntaxNode
+    {
+        public readonly ImmutableArray<PhpArrayElementSyntaxNode> Elements;
+
+        public PhpArraySyntaxNode(ImmutableArray<PhpArrayElementSyntaxNode> elements)
+        {
+            Elements = elements;
+        }
+
+        public static PhpArraySyntaxNode Parse(PhpTokeniser tokeniser)
+        {
+            tokeniser.SkipWhitespace();
+            tokeniser.SkipPattern(new[] { '[' });
+
+            var elements = ImmutableArray.CreateBuilder<PhpArrayElementSyntaxNode>();
+
+            while (true)
+            {
+                tokeniser.SkipWhitespace();
+                if (tokeniser.GetTrivia() == ']')
+                    break;
+
+                elements.Add(PhpArrayElementSyntaxNode.Parse(tokeniser));
+            }
+
+            // Skip trailing trivia.
+            tokeniser.Advance();
+            tokeniser.SkipWhitespace();
+
+            return new PhpArraySyntaxNode(elements.ToImmutableArray());
+        }
+    }
+}

--- a/LocalisationAnalyser.Tools/Php/PhpLiteralSyntaxNode.cs
+++ b/LocalisationAnalyser.Tools/Php/PhpLiteralSyntaxNode.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace LocalisationAnalyser.Tools.Php
+{
+    /// <summary>
+    /// An abstract PHP syntax node for a literal.
+    /// </summary>
+    public abstract class PhpLiteralSyntaxNode : PhpSyntaxNode
+    {
+    }
+}

--- a/LocalisationAnalyser.Tools/Php/PhpStringLiteralSyntaxNode.cs
+++ b/LocalisationAnalyser.Tools/Php/PhpStringLiteralSyntaxNode.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text;
+
+namespace LocalisationAnalyser.Tools.Php
+{
+    /// <summary>
+    /// A PHP syntax node for a string literal.
+    /// </summary>
+    public class PhpStringLiteralSyntaxNode : PhpLiteralSyntaxNode
+    {
+        public readonly string Text;
+
+        public PhpStringLiteralSyntaxNode(string text)
+        {
+            Text = text;
+        }
+
+        public static PhpStringLiteralSyntaxNode Parse(PhpTokeniser tokeniser)
+        {
+            tokeniser.SkipWhitespace();
+
+            char trivia = tokeniser.GetTrivia();
+
+            // Skip leading trivia.
+            tokeniser.Advance();
+
+            var stringBuilder = new StringBuilder();
+            bool isEscaping = false;
+
+            while (isEscaping || tokeniser.GetTrivia() != trivia)
+            {
+                var token = tokeniser.GetTrivia();
+                tokeniser.Advance();
+
+                if (token == '\\' && !isEscaping)
+                {
+                    isEscaping = true;
+                    continue;
+                }
+
+                stringBuilder.Append(token);
+                isEscaping = false;
+            }
+
+            // Skip trailing trivia.
+            tokeniser.Advance();
+            tokeniser.SkipWhitespace();
+
+            return new PhpStringLiteralSyntaxNode(stringBuilder.ToString());
+        }
+    }
+}

--- a/LocalisationAnalyser.Tools/Php/PhpSyntaxNode.cs
+++ b/LocalisationAnalyser.Tools/Php/PhpSyntaxNode.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace LocalisationAnalyser.Tools.Php
+{
+    /// <summary>
+    /// An abstract PHP syntax node.
+    /// </summary>
+    public abstract class PhpSyntaxNode
+    {
+    }
+}

--- a/LocalisationAnalyser.Tools/Php/PhpTokeniser.cs
+++ b/LocalisationAnalyser.Tools/Php/PhpTokeniser.cs
@@ -117,33 +117,44 @@ namespace LocalisationAnalyser.Tools.Php
             if (TryGetTrivia(out trivia) && trivia != '/')
                 return;
 
-            // // comment pattern.
-            if (TryPeekNext(out trivia) && trivia == '/')
-            {
-                while (TryGetTrivia(out trivia) && trivia != '\n')
-                    TryAdvance();
-                TryAdvance();
+            // Try to peek the next one after a / character.
+            if (!TryPeekNext(out trivia))
                 return;
-            }
 
-            // /* comment pattern.
-            if (TryPeekNext(out trivia) && trivia == '*')
+            switch (trivia)
             {
-                TryAdvance();
-                TryAdvance();
+                case '/':
+                    // Line comment
+                    while (TryGetTrivia(out trivia) && trivia != '\n')
+                        TryAdvance();
+                    TryAdvance();
+                    break;
 
-                while (true)
-                {
-                    if (TryGetTrivia(out trivia) && trivia == '*' && TryPeekNext(out var nextTrivia) && nextTrivia == '/')
+                case '*':
+                    // Block comment.
+                    TryAdvance();
+                    TryAdvance();
+
+                    while (true)
                     {
+                        if (TryGetTrivia(out trivia) && trivia == '*' && TryPeekNext(out var nextTrivia) && nextTrivia == '/')
+                        {
+                            TryAdvance();
+                            TryAdvance();
+                            break;
+                        }
+
                         TryAdvance();
-                        TryAdvance();
-                        break;
                     }
 
-                    TryAdvance();
-                }
+                    break;
+
+                default:
+                    return;
             }
+
+            // Continue skipping any remaining whitespace.
+            SkipWhitespace();
         }
 
         /// <summary>

--- a/LocalisationAnalyser.Tools/Php/PhpTokeniser.cs
+++ b/LocalisationAnalyser.Tools/Php/PhpTokeniser.cs
@@ -1,0 +1,180 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace LocalisationAnalyser.Tools.Php
+{
+    /// <summary>
+    /// Tokenises a PHP file.
+    /// </summary>
+    public class PhpTokeniser
+    {
+        private readonly string content;
+
+        private int currentIndex;
+        private int currentLine;
+        private int currentColumn;
+
+        /// <summary>
+        /// Creates a new <see cref="PhpTokeniser"/>.
+        /// </summary>
+        /// <param name="content">The PHP content.</param>
+        public PhpTokeniser(string content)
+        {
+            this.content = content;
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the current trivia, returning a value indicating whether the retrieval succeeded.
+        /// </summary>
+        /// <param name="trivia">The trivia, if any.</param>
+        /// <returns>Whether the trivia was retrieved successfully.</returns>
+        public bool TryGetTrivia(out char trivia)
+        {
+            if (currentIndex >= content.Length)
+            {
+                trivia = default;
+                return false;
+            }
+
+            trivia = content[currentIndex];
+            return true;
+        }
+
+        /// <summary>
+        /// Retrieves the current trivia.
+        /// </summary>
+        /// <returns>The trivia.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when at the end of the PHP content.</exception>
+        public char GetTrivia()
+        {
+            if (currentIndex >= content.Length)
+                ThrowError("EOF");
+
+            return content[currentIndex];
+        }
+
+        /// <summary>
+        /// Attempts to advance to the next trivia.
+        /// </summary>
+        public void TryAdvance()
+        {
+            if (currentIndex >= content.Length)
+                return;
+
+            Advance();
+        }
+
+        /// <summary>
+        /// Advances to the next trivia.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when at the end of the PHP content.</exception>
+        public void Advance()
+        {
+            if (currentIndex == content.Length)
+                ThrowError("Failed to advance, reached EOF.");
+
+            if (GetTrivia() == '\n')
+            {
+                currentLine++;
+                currentColumn = 0;
+            }
+            else
+                currentColumn++;
+
+            currentIndex++;
+        }
+
+        /// <summary>
+        /// Attempts to peek the next trivia, returning a value indicating whether the retrieval succeeded.
+        /// </summary>
+        /// <param name="trivia">The next trivia, if any.</param>
+        /// <returns>Whether the trivia was retrieved successfully.</returns>
+        public bool TryPeekNext(out char trivia)
+        {
+            if (currentIndex + 1 >= content.Length)
+            {
+                trivia = default;
+                return false;
+            }
+
+            trivia = content[currentIndex + 1];
+            return true;
+        }
+
+        /// <summary>
+        /// Skips all current whitespace and comments.
+        /// </summary>
+        public void SkipWhitespace()
+        {
+            char trivia;
+
+            while (TryGetTrivia(out trivia) && char.IsWhiteSpace(trivia))
+                TryAdvance();
+
+            if (TryGetTrivia(out trivia) && trivia != '/')
+                return;
+
+            // // comment pattern.
+            if (TryPeekNext(out trivia) && trivia == '/')
+            {
+                while (TryGetTrivia(out trivia) && trivia != '\n')
+                    TryAdvance();
+                TryAdvance();
+                return;
+            }
+
+            // /* comment pattern.
+            if (TryPeekNext(out trivia) && trivia == '*')
+            {
+                TryAdvance();
+                TryAdvance();
+
+                while (true)
+                {
+                    if (TryGetTrivia(out trivia) && trivia == '*' && TryPeekNext(out var nextTrivia) && nextTrivia == '/')
+                    {
+                        TryAdvance();
+                        TryAdvance();
+                        break;
+                    }
+
+                    TryAdvance();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Skips a trivia pattern, throwing an exception where the pattern does not match the given input.
+        /// </summary>
+        /// <param name="pattern">The pattern to skip.</param>
+        /// <exception cref="InvalidOperationException">When the current pattern does not match the given input..</exception>
+        public void SkipPattern(ReadOnlySpan<char> pattern)
+        {
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                if (GetTrivia() != pattern[i])
+                    ThrowError($"Invalid token (expected {pattern.ToString()})");
+
+                Advance();
+            }
+        }
+
+        /// <summary>
+        /// Throws a detailed exception containing the given error message.
+        /// </summary>
+        /// <param name="description">The error description.</param>
+        [DoesNotReturn]
+        public void ThrowError(string description)
+            => throw ConstructError(description);
+
+        /// <summary>
+        /// Constructs a detailed exception containing the given error message.
+        /// </summary>
+        /// <param name="description">The error description.</param>
+        public Exception ConstructError(string description)
+            => new InvalidOperationException($"{description} at {currentLine}:{currentColumn}.");
+    }
+}

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -138,6 +138,12 @@ namespace LocalisationAnalyser.Tools
             // The localisation members to generate files from.
             var members = (await getMembersFromPhpFile(file)).ToArray();
 
+            if (members.Length == 0)
+            {
+                Console.WriteLine("Skipped (empty).");
+                return;
+            }
+
             if (langName == en_lang_name)
             {
                 // Create the .cs file.

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -199,8 +199,13 @@ namespace LocalisationAnalyser.Tools
                             stringValue = $"{stringValue[..match.Index]}{{{formatIndices[j]}}}{stringValue[(match.Index + match.Length)..]}";
                         }
 
+                        // This handles cases such as:
+                        // A.B_c
+                        // A._
+                        string memberName = elementKey.Humanize().Dehumanize();
+
                         yield return new LocalisationMember(
-                            elementKey.Pascalize(),
+                            memberName,
                             elementKey,
                             stringValue,
                             formatParamNames.Select(p => new LocalisationParameter("string", p.Camelize())).ToArray());

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -144,27 +144,26 @@ namespace LocalisationAnalyser.Tools
                 return;
             }
 
+            // Only create the .cs file for the english localisation.
             if (langName == en_lang_name)
             {
-                // Create the .cs file.
                 var localisationFile = new LocalisationFile(nameSpace, Path.GetFileNameWithoutExtension(targetLocalisationFile), name, members);
                 using (var fs = File.Open(targetLocalisationFile, FileMode.Create, FileAccess.ReadWrite))
                     await localisationFile.WriteAsync(fs, new AdhocWorkspace());
 
                 Console.WriteLine($"  -> {targetLocalisationFile}");
             }
-            else
-            {
-                using (var fs = File.Open(targetResourcesFile, FileMode.Create, FileAccess.ReadWrite))
-                using (var resWriter = new ResXResourceWriter(fs, getResourceTypeName))
-                {
-                    foreach (var member in members)
-                        resWriter.AddResource(member.Key, member.EnglishText);
-                    resWriter.Generate();
-                }
 
-                Console.WriteLine($"  -> {targetResourcesFile}");
+            // Create the .resx file.
+            using (var fs = File.Open(targetResourcesFile, FileMode.Create, FileAccess.ReadWrite))
+            using (var resWriter = new ResXResourceWriter(fs, getResourceTypeName))
+            {
+                foreach (var member in members)
+                    resWriter.AddResource(member.Key, member.EnglishText);
+                resWriter.Generate();
             }
+
+            Console.WriteLine($"  -> {targetResourcesFile}");
         }
 
         private static async Task<IEnumerable<LocalisationMember>> getMembersFromPhpFile(string file)

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -204,6 +204,9 @@ namespace LocalisationAnalyser.Tools
                         // A._
                         string memberName = elementKey.Humanize().Dehumanize();
 
+                        if (memberName == string.Empty)
+                            memberName = "Default";
+
                         yield return new LocalisationMember(
                             memberName,
                             elementKey,

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -138,27 +138,27 @@ namespace LocalisationAnalyser.Tools
             // The localisation members to generate files from.
             var members = (await getMembersFromPhpFile(file)).ToArray();
 
-            // Create the .resx file.
-            using (var fs = File.Open(targetResourcesFile, FileMode.Create, FileAccess.ReadWrite))
-            using (var resWriter = new ResXResourceWriter(fs, getResourceTypeName))
+            if (langName == en_lang_name)
             {
-                foreach (var member in members)
-                    resWriter.AddResource(member.Key, member.EnglishText);
-                resWriter.Generate();
+                // Create the .cs file.
+                var localisationFile = new LocalisationFile(nameSpace, Path.GetFileNameWithoutExtension(targetLocalisationFile), name, members);
+                using (var fs = File.Open(targetLocalisationFile, FileMode.Create, FileAccess.ReadWrite))
+                    await localisationFile.WriteAsync(fs, new AdhocWorkspace());
+
+                Console.WriteLine($"  -> {targetLocalisationFile}");
             }
+            else
+            {
+                using (var fs = File.Open(targetResourcesFile, FileMode.Create, FileAccess.ReadWrite))
+                using (var resWriter = new ResXResourceWriter(fs, getResourceTypeName))
+                {
+                    foreach (var member in members)
+                        resWriter.AddResource(member.Key, member.EnglishText);
+                    resWriter.Generate();
+                }
 
-            Console.WriteLine($"  -> {targetResourcesFile}");
-
-            // Only generate the localisation file for the english language. All others only exist as resources.
-            if (langName != en_lang_name)
-                return;
-
-            // Create the .cs file.
-            var localisationFile = new LocalisationFile(nameSpace, Path.GetFileNameWithoutExtension(targetLocalisationFile), name, members);
-            using (var fs = File.Open(targetLocalisationFile, FileMode.Create, FileAccess.ReadWrite))
-                await localisationFile.WriteAsync(fs, new AdhocWorkspace());
-
-            Console.WriteLine($"  -> {targetLocalisationFile}");
+                Console.WriteLine($"  -> {targetResourcesFile}");
+            }
         }
 
         private static async Task<IEnumerable<LocalisationMember>> getMembersFromPhpFile(string file)

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -29,7 +29,7 @@ namespace LocalisationAnalyser.Tools
                 },
             };
 
-            var phpToResx = new Command("from-php", "Generates resource (.resx) files from all PHP files in the target directory recursively.")
+            var phpToResx = new Command("from-php", "Generates side-by-side resource (.resx) files for all PHP files recursively in the target directory.")
             {
                 new Argument("directory")
                 {
@@ -37,7 +37,7 @@ namespace LocalisationAnalyser.Tools
                 }
             };
 
-            toResx.Handler = CommandHandler.Create<string>(convertToResX);
+            toResx.Handler = CommandHandler.Create<string>(projectToResX);
             phpToResx.Handler = CommandHandler.Create<string>(phpToResX);
 
             await new RootCommand("osu! Localisation Tools")
@@ -47,7 +47,7 @@ namespace LocalisationAnalyser.Tools
             }.InvokeAsync(args);
         }
 
-        private static async Task convertToResX(string projectFile)
+        private static async Task projectToResX(string projectFile)
         {
             Console.WriteLine($"Converting all localisation files in {projectFile}...");
 

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -159,7 +159,13 @@ namespace LocalisationAnalyser.Tools
             using (var resWriter = new ResXResourceWriter(fs, getResourceTypeName))
             {
                 foreach (var member in members)
+                {
+                    if (string.IsNullOrEmpty(member.EnglishText) && langName != en_lang_name)
+                        continue;
+
                     resWriter.AddResource(member.Key, member.EnglishText);
+                }
+
                 resWriter.Generate();
             }
 

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -117,7 +117,6 @@ namespace LocalisationAnalyser.Tools
 
                 string targetLocalisation = Path.Combine(projectLocalisationDirectory, Path.ChangeExtension($"{name}Strings", "cs"));
                 string targetResources = Path.Combine(projectLocalisationDirectory, Path.ChangeExtension(name, "resx"));
-                string targetPrefix = $"osu.Game.Localisation.Web.{name}";
 
                 // Get the first array from the PHP file.
                 string phpContents = await File.ReadAllTextAsync(file);
@@ -137,7 +136,7 @@ namespace LocalisationAnalyser.Tools
                 }
 
                 // Create the .cs file.
-                var localisationFile = new LocalisationFile("osu.Game.Localisation.Web", Path.GetFileNameWithoutExtension(targetLocalisation), targetPrefix, localisations);
+                var localisationFile = new LocalisationFile("osu.Game.Localisation.Web", Path.GetFileNameWithoutExtension(targetLocalisation), name, localisations);
                 using (var fs = File.Open(targetLocalisation, FileMode.Create, FileAccess.ReadWrite))
                     await localisationFile.WriteAsync(fs, new AdhocWorkspace());
 

--- a/LocalisationAnalyser.sln
+++ b/LocalisationAnalyser.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LocalisationAnalyser.Tests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LocalisationAnalyser.Tools", "LocalisationAnalyser.Tools\LocalisationAnalyser.Tools.csproj", "{184910C9-93D2-4B25-98F3-D174677F093C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LocalisationAnalyser.Tools.Tests", "LocalisationAnalyser.Tools.Tests\LocalisationAnalyser.Tools.Tests.csproj", "{80F80892-537F-4BB0-B46D-A50798665F7C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{184910C9-93D2-4B25-98F3-D174677F093C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{184910C9-93D2-4B25-98F3-D174677F093C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{184910C9-93D2-4B25-98F3-D174677F093C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80F80892-537F-4BB0-B46D-A50798665F7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80F80892-537F-4BB0-B46D-A50798665F7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80F80892-537F-4BB0-B46D-A50798665F7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80F80892-537F-4BB0-B46D-A50798665F7C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
+++ b/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
@@ -56,14 +56,14 @@ namespace LocalisationAnalyser.Localisation
             var paramList = SyntaxFactory.ParameterList(
                 SyntaxFactory.SeparatedList(
                     member.Parameters.Select(param => SyntaxFactory.Parameter(
-                                                                       SyntaxFactory.Identifier(param.Name))
+                                                                       GenerateIdentifier(param.Name))
                                                                    .WithType(
                                                                        SyntaxFactory.IdentifierName(param.Type)))));
 
             var argList = SyntaxFactory.ArgumentList(
                 SyntaxFactory.SeparatedList(
                     member.Parameters.Select(param => SyntaxFactory.Argument(
-                        SyntaxFactory.IdentifierName(param.Name)))));
+                        GenerateIdentifierName(param.Name)))));
 
             return SyntaxFactory.ParseMemberDeclaration(
                 string.Format(SyntaxTemplates.METHOD_MEMBER_TEMPLATE,
@@ -97,6 +97,28 @@ namespace LocalisationAnalyser.Localisation
         /// </summary>
         public static MemberDeclarationSyntax GenerateGetKeySyntax()
             => SyntaxFactory.ParseMemberDeclaration(SyntaxTemplates.GET_KEY_METHOD_TEMPLATE)!;
+
+        /// <summary>
+        /// Generates an identifier <see cref="SyntaxToken"/> from a string, taking into account reserved language keywords.
+        /// </summary>
+        /// <param name="name">The string to generate an identifier for.</param>
+        public static SyntaxToken GenerateIdentifier(string name)
+        {
+            if (SyntaxFacts.IsReservedKeyword(SyntaxFacts.GetKeywordKind(name)))
+                name = $"@{name}";
+            return SyntaxFactory.Identifier(name);
+        }
+
+        /// <summary>
+        /// Generates an <see cref="IdentifierNameSyntax"/> from a string, taking into account reserved language keywords.
+        /// </summary>
+        /// <param name="name">The string to generate an identifier for.</param>
+        public static IdentifierNameSyntax GenerateIdentifierName(string name)
+        {
+            if (SyntaxFacts.IsReservedKeyword(SyntaxFacts.GetKeywordKind(name)))
+                name = $"@{name}";
+            return SyntaxFactory.IdentifierName(name);
+        }
 
         /// <summary>
         /// Converts a string literal to its verbatim representation. Assumes that the string is already non-verbatim.

--- a/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
+++ b/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using System.Text;
+using System.Web;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -46,7 +47,7 @@ namespace LocalisationAnalyser.Localisation
                     member.Name,
                     member.Key,
                     convertToVerbatim(member.EnglishText),
-                    member.EnglishText))!;
+                    EncodeXmlDoc(member.EnglishText)))!;
 
         /// <summary>
         /// Generates the syntax for a method member.
@@ -72,7 +73,7 @@ namespace LocalisationAnalyser.Localisation
                     member.Key,
                     convertToVerbatim(member.EnglishText),
                     trimParens(Formatter.Format(argList, workspace).ToFullString()), // The entire string minus the parens
-                    member.EnglishText))!; // Todo: Improve xmldoc
+                    EncodeXmlDoc(member.EnglishText)))!;
 
             static string trimParens(string input) => input.Substring(1, input.Length - 2);
         }
@@ -118,6 +119,30 @@ namespace LocalisationAnalyser.Localisation
             if (SyntaxFacts.IsReservedKeyword(SyntaxFacts.GetKeywordKind(name)))
                 name = $"@{name}";
             return SyntaxFactory.IdentifierName(name);
+        }
+
+        public static string EncodeXmlDoc(string xmlDoc)
+        {
+            var lines = xmlDoc.Split('\n');
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var sb = new StringBuilder();
+
+                sb.Append("/// ");
+
+                if (i == 0)
+                    sb.Append("\"");
+
+                sb.Append(HttpUtility.HtmlEncode(lines[i]));
+
+                if (i == lines.Length - 1)
+                    sb.Append("\"");
+
+                lines[i] = sb.ToString();
+            }
+
+            return string.Join("\n", lines);
         }
 
         /// <summary>

--- a/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
+++ b/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using System.Text;
 using System.Web;
@@ -142,7 +143,7 @@ namespace LocalisationAnalyser.Localisation
                 lines[i] = sb.ToString();
             }
 
-            return string.Join("\n", lines);
+            return string.Join(Environment.NewLine, lines);
         }
 
         /// <summary>

--- a/LocalisationAnalyser/Localisation/SyntaxTemplates.cs
+++ b/LocalisationAnalyser/Localisation/SyntaxTemplates.cs
@@ -46,7 +46,7 @@ private const string {PREFIX_CONST_NAME} = @""{{0}}"";
         /// </remarks>
         public static readonly string PROPERTY_MEMBER_TEMPLATE = $@"
 /// <summary>
-/// ""{{3}}""
+{{3}}
 /// </summary>
 public static {MEMBER_RETURN_TYPE} {{0}} => new {MEMBER_CONSTRUCTION_TYPE}({GET_KEY_METHOD_NAME}(@""{{1}}""), @""{{2}}"");
 ";
@@ -64,7 +64,7 @@ public static {MEMBER_RETURN_TYPE} {{0}} => new {MEMBER_CONSTRUCTION_TYPE}({GET_
         /// </remarks>
         public static readonly string METHOD_MEMBER_TEMPLATE = $@"
 /// <summary>
-/// ""{{5}}""
+{{5}}
 /// </summary>
 public static {MEMBER_RETURN_TYPE} {{0}}{{1}} => new {MEMBER_CONSTRUCTION_TYPE}({GET_KEY_METHOD_NAME}(@""{{2}}""), @""{{3}}"", {{4}});
 ";


### PR DESCRIPTION
`dotnet localisation from-php /home/Repos/osu-web /home/Repos/osu/osu.Game/osu.Game.csproj`

The little tokeniser I wrote doesn't support the full range of PHP syntax, for example non-string keys/values, but it passes all localisation files currently in osu!web.

Notes:
1. Nested localisations are namespaced via `.` (e.g. `beatmapsets.resx`: `panel.download.direct`).
2. It doesn't change keys other than the namespacing above. Some keys contain `-` and others contain `_` - both of these remain unchanged like the rest.
3. It replaces `:text` with string format args (e.g. from `beatmaps.resx`, `Deleted by :editor :delete_time.` becomes `Deleted by {0} {1}.`.