### PR TITLE
Reverse crowdin mappings in from-php command

### DIFF
--- a/LocalisationAnalyser.Tools/LocalisationAnalyser.Tools.csproj
+++ b/LocalisationAnalyser.Tools/LocalisationAnalyser.Tools.csproj
@@ -30,6 +30,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.3.1" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
         <PackageReference Include="ResXResourceReader.NetStandard" Version="1.0.1" />
+        <PackageReference Include="YamlDotNet" Version="11.2.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This looks to match other projects:
- Roslyn: https://github.com/dotnet/roslyn/tree/main/src/Analyzers/CSharp/Analyzers/xlf
- Humanizr: https://github.com/Humanizr/Humanizer/tree/main/src/Humanizer/Properties

Note in particular:
1. `zh-CN` instead of `zh`. Keeping the redundant particle.
2. `pt-BR` instead of `pt-br`. Keeping the standard casing.

Without this, the compiler spits out errors on a fresh publish - something like "could not find part of the path pt-br" even though the folder "pt-BR" exists.