### PR TITLE
Remove duplicate localisation keys

### DIFF
--- a/LocalisationAnalyser.Tools/LocalisationMemberKeyEqualityComparer.cs
+++ b/LocalisationAnalyser.Tools/LocalisationMemberKeyEqualityComparer.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using LocalisationAnalyser.Localisation;
+
+namespace LocalisationAnalyser.Tools
+{
+    public class LocalisationMemberKeyEqualityComparer : IEqualityComparer<LocalisationMember>
+    {
+        public bool Equals(LocalisationMember? x, LocalisationMember? y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+
+            if (ReferenceEquals(x, null))
+                return false;
+
+            if (ReferenceEquals(y, null))
+                return false;
+
+            if (x.GetType() != y.GetType())
+                return false;
+
+            return x.Key == y.Key;
+        }
+
+        public int GetHashCode(LocalisationMember obj) => obj.Key.GetHashCode();
+    }
+}

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -152,7 +152,7 @@ namespace LocalisationAnalyser.Tools
                 if (g.Count() == 1)
                     continue;
 
-                await printWarning($"  -> WARNING: Skipping duplicate key \"{g.Key}\" ({string.Join(", ", g)})");
+                await printWarning($"  -> WARNING: Skipping duplicate key \"{g.Key}\" ({string.Join(", ", g)}) in {file}.");
             }
 
             // Convert keys to lower-case and remove duplicates.


### PR DESCRIPTION
Removing duplicate keys locally and printing warnings to:
* Not outright ban the warnings osu!-side.
* Have a log of warnings somewhere that could be reported to osu-web if necessary.
  * Can run `dotnet run -- from-php ~/Repos/osu-web/ ~/Repos/osu-resources/osu.Game.Resources/osu.Game.Resources.csproj 2>err.log` to list just the warnings.

Also `.ToLower()`ing the keys since resx is case-insensitive.