### PR TITLE
Add analyser prefix customisation and output directory to command

### DIFF
--- a/LocalisationAnalyser.Tests/CodeFixes/AbstractLocaliseStringCodeFixTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/AbstractLocaliseStringCodeFixTests.cs
@@ -45,11 +45,25 @@ namespace LocalisationAnalyser.Tests.CodeFixes
 
         private string getFileNameFromResourceName(string resourceNamespace, string resourceName)
         {
-            resourceName = resourceName.Replace(resourceNamespace, string.Empty)[1..]
-                                       .Replace(".txt", string.Empty)
-                                       .Replace('.', '/');
+            string extension = Path.GetExtension(resourceName);
 
-            return $"{Path.GetFileName(resourceName)}.cs";
+            resourceName = resourceName.Replace(resourceNamespace, string.Empty)[1..]
+                                       .Replace(extension, string.Empty);
+
+            if (extension == ".txt")
+            {
+                // .txt files are translated to .cs. We provide only the file name, not the path.
+                resourceName = resourceName[(resourceName.LastIndexOf('.') + 1)..];
+                resourceName = $"{Path.GetFileName(resourceName)}.cs";
+            }
+            else
+            {
+                // For all other files, we provide the full path.
+                resourceName = resourceName.Replace('.', '/');
+                resourceName = $"/{resourceName}{extension}";
+            }
+
+            return resourceName;
         }
 
         protected abstract Task Verify((string filename, string content)[] sources, (string filename, string content)[] fixedSources);

--- a/LocalisationAnalyser.Tests/CodeFixes/AbstractLocaliseStringCodeFixTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/AbstractLocaliseStringCodeFixTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using LocalisationAnalyser.Tests.Helpers.IO;
 
 namespace LocalisationAnalyser.Tests.CodeFixes
 {
@@ -54,8 +55,7 @@ namespace LocalisationAnalyser.Tests.CodeFixes
             // .txt files are converted to .cs.
             resourceName = extension == ".txt" ? $"{resourceName}.cs" : $"{resourceName}{extension}";
 
-            // Absolute file paths.
-            return $"/{resourceName}";
+            return new MockFileSystem().Path.GetFullPath(resourceName);
         }
 
         protected abstract Task Verify((string filename, string content)[] sources, (string filename, string content)[] fixedSources);

--- a/LocalisationAnalyser.Tests/CodeFixes/LocaliseClassStringCodeFixTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/LocaliseClassStringCodeFixTests.cs
@@ -16,6 +16,7 @@ namespace LocalisationAnalyser.Tests.CodeFixes
         [InlineData("VerbatimString")]
         [InlineData("InterpolatedString")]
         [InlineData("InterpolatedStringWithQuotes")]
+        [InlineData("CustomPrefix")]
         public async Task Check(string name) => await RunTest(name);
 
         protected override Task Verify((string filename, string content)[] sources, (string filename, string content)[] fixedSources)

--- a/LocalisationAnalyser.Tests/Helpers/IO/MockPath.cs
+++ b/LocalisationAnalyser.Tests/Helpers/IO/MockPath.cs
@@ -21,5 +21,7 @@ namespace LocalisationAnalyser.Tests.Helpers.IO
         public string ChangeExtension(string path, string newExtension) => mockFs.Path.ChangeExtension(path, newExtension);
 
         public string GetFileName(string path) => mockFs.Path.GetFileName(path);
+
+        public string GetFullPath(string path) => mockFs.Path.GetFullPath(path);
     }
 }

--- a/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
+++ b/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
@@ -50,7 +50,7 @@ namespace {test_namespace}
 
             Assert.Equal(localisation.Namespace, test_namespace);
             Assert.Equal(localisation.Name, test_class_name);
-            Assert.Equal(localisation.Prefix, test_class_name);
+            Assert.Equal(localisation.Prefix, $"{test_namespace}.{test_class_name}");
             Assert.Empty(localisation.Members);
         }
 
@@ -278,7 +278,7 @@ namespace {test_namespace}
         private async Task setupLocalisation(params LocalisationMember[] members)
         {
             using (var stream = mockFs.FileInfo.FromFileName(test_file_name).OpenWrite())
-                await new LocalisationFile(test_namespace, test_class_name, test_class_name, members).WriteAsync(stream, workspace);
+                await new LocalisationFile(test_namespace, test_class_name, $"{test_namespace}.{test_class_name}", members).WriteAsync(stream, workspace);
         }
 
         private void checkResult(string inner)

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/CustomPrefix/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/CustomPrefix/Fixed/Localisation/ProgramStrings.txt
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace TestProject.Localisation
+{
+    public static class ProgramStrings
+    {
+        private const string prefix = @"CustomNamespace.Program";
+
+        /// <summary>
+        /// "abc"
+        /// </summary>
+        public static LocalisableString Abc => new TranslatableString(getKey(@"abc"), @"abc");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/CustomPrefix/Fixed/Program.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/CustomPrefix/Fixed/Program.txt
@@ -1,0 +1,12 @@
+using TestProject.Localisation;
+
+namespace Test
+{
+    class Program
+    {
+        static void Main()
+        {
+            string x = ProgramStrings.Abc;
+        }
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/CustomPrefix/Sources/.editorconfig
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/CustomPrefix/Sources/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.cs]
+dotnet_diagnostic.OLOC001.prefix_namespace = CustomNamespace

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/CustomPrefix/Sources/Program.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/CustomPrefix/Sources/Program.txt
@@ -1,0 +1,10 @@
+namespace Test
+{
+    class Program
+    {
+        static void Main()
+        {
+            string x = [|"abc"|];
+        }
+    }
+}

--- a/LocalisationAnalyser.Tests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/LocalisationAnalyser.Tests/Verifiers/CSharpCodeFixVerifier.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -24,10 +25,40 @@ namespace LocalisationAnalyser.Tests.Verifiers
             var test = new Test();
 
             foreach (var s in sources)
-                test.TestState.Sources.Add(s);
+            {
+                switch (Path.GetExtension(s.filename))
+                {
+                    case ".cs":
+                        test.TestState.Sources.Add(s);
+                        break;
+
+                    case ".editorconfig":
+                        test.TestState.AnalyzerConfigFiles.Add(s);
+                        break;
+
+                    default:
+                        test.TestState.AdditionalFiles.Add(s);
+                        break;
+                }
+            }
 
             foreach (var s in fixedSources)
-                test.FixedState.Sources.Add(s);
+            {
+                switch (Path.GetExtension(s.filename))
+                {
+                    case ".cs":
+                        test.FixedState.Sources.Add(s);
+                        break;
+
+                    case ".editorconfig":
+                        test.FixedState.AnalyzerConfigFiles.Add(s);
+                        break;
+
+                    default:
+                        test.FixedState.AdditionalFiles.Add(s);
+                        break;
+                }
+            }
 
             test.ExpectedDiagnostics.AddRange(expected);
             await test.RunAsync(CancellationToken.None);

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -167,7 +167,7 @@ namespace LocalisationAnalyser.Tools
             // Only create the .cs file for the english localisation.
             if (langName == en_lang_name)
             {
-                var localisationFile = new LocalisationFile(nameSpace, Path.GetFileNameWithoutExtension(targetLocalisationFile), name, members);
+                var localisationFile = new LocalisationFile(nameSpace, Path.GetFileNameWithoutExtension(targetLocalisationFile), $"{nameSpace}.{name}", members);
                 using (var fs = File.Open(targetLocalisationFile, FileMode.Create, FileAccess.ReadWrite))
                     await localisationFile.WriteAsync(fs, new AdhocWorkspace());
 

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -38,7 +38,7 @@ namespace LocalisationAnalyser.Tools
                     IsRequired = false,
                     Description = "The path to output the resource files into.\n"
                                   + "By default, the .resx files are output alongside their .cs counterparts."
-                }.ExistingOnly()
+                }.LegalFilePathsOnly()
             };
 
             var phpToResx = new Command("from-php", "Converts localisations from the target osu!web directory into the target project.")
@@ -94,6 +94,9 @@ namespace LocalisationAnalyser.Tools
                 string targetDirectory = output != null ? output.FullName : Path.GetDirectoryName(file.FilePath)!;
                 string targetFileName = localisationFile.Prefix[(localisationFile.Prefix.LastIndexOf('.') + 1)..];
                 string resxFile = Path.Combine(targetDirectory, $"{targetFileName}.resx");
+
+                // For custom output directories.
+                Directory.CreateDirectory(targetDirectory);
 
                 using (var fs = File.Open(resxFile, FileMode.Create, FileAccess.ReadWrite))
                 using (var resWriter = new ResXResourceWriter(fs, getResourceTypeName))

--- a/LocalisationAnalyser/Abstractions/IO/Default/DefaultPath.cs
+++ b/LocalisationAnalyser/Abstractions/IO/Default/DefaultPath.cs
@@ -14,5 +14,7 @@ namespace LocalisationAnalyser.Abstractions.IO.Default
         public string ChangeExtension(string path, string newExtension) => Path.ChangeExtension(path, newExtension);
 
         public string GetFileName(string path) => Path.GetFileName(path);
+
+        public string GetFullPath(string path) => Path.GetFullPath(path);
     }
 }

--- a/LocalisationAnalyser/Abstractions/IO/IPath.cs
+++ b/LocalisationAnalyser/Abstractions/IO/IPath.cs
@@ -12,5 +12,7 @@ namespace LocalisationAnalyser.Abstractions.IO
         string ChangeExtension(string path, string newExtension);
 
         string GetFileName(string path);
+
+        string GetFullPath(string path);
     }
 }

--- a/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
@@ -266,15 +266,16 @@ namespace LocalisationAnalyser.CodeFixes
                 }
             }
 
-            return (localisationFile, new LocalisationFile(localisationNamespace, localisationName, GetLocalisationPrefix(incomingClassName)));
+            return (localisationFile, new LocalisationFile(localisationNamespace, localisationName, GetLocalisationPrefix(localisationNamespace, incomingClassName)));
         }
 
         /// <summary>
-        /// Retrieves un-namespaced prefix for the localisation class corresponding to a given class name.
+        /// Retrieves "prefix" value for the localisation class corresponding to a given class name and namespace.
         /// </summary>
+        /// <param name="namespace">The namespace in which the localisation class will be placed.</param>
         /// <param name="className">The name of the original class.</param>
-        /// <returns>The un-namespaced prefix.</returns>
-        protected virtual string GetLocalisationPrefix(string className) => className;
+        /// <returns>The prefix value.</returns>
+        protected virtual string GetLocalisationPrefix(string @namespace, string className) => $"{@namespace}.{className}";
 
         /// <summary>
         /// Retrieves the name of the localisation class corresponding to a given class name.

--- a/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
@@ -204,7 +204,7 @@ namespace LocalisationAnalyser.CodeFixes
                     if (project.Solution.Workspace.CanApplyChange(ApplyChangesKind.AddDocument) && project.Documents.All(d => d.FilePath != file.FullName))
                     {
                         var classDocument = project.AddDocument(
-                            fileSystem.Path.GetFileName(file.FullName),
+                            file.FullName,
                             file.FileSystem.File.ReadAllText(file.FullName),
                             Enumerable.Empty<string>(),
                             file.FullName);

--- a/LocalisationAnalyser/CodeFixes/LocaliseCommonStringCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/LocaliseCommonStringCodeFixProvider.cs
@@ -26,7 +26,7 @@ namespace LocalisationAnalyser.CodeFixes
         {
         }
 
-        protected override string GetLocalisationPrefix(string className) => SyntaxTemplates.COMMON_STRINGS_CLASS_NAME;
+        protected override string GetLocalisationPrefix(string @namespace, string className) => base.GetLocalisationPrefix(@namespace, SyntaxTemplates.COMMON_STRINGS_CLASS_NAME);
 
         protected override string GetLocalisationFileName(string className) => $"{SyntaxTemplates.COMMON_STRINGS_CLASS_NAME}{SyntaxTemplates.STRINGS_FILE_SUFFIX}";
     }

--- a/LocalisationAnalyser/Localisation/LocalisationFile.cs
+++ b/LocalisationAnalyser/Localisation/LocalisationFile.cs
@@ -88,7 +88,7 @@ namespace LocalisationAnalyser.Localisation
                 if (string.IsNullOrEmpty(walker.Prefix))
                     throw new MalformedLocalisationException("The localisation file contains no prefix identifier");
 
-                return new LocalisationFile(walker.Namespace!, walker.Name!, walker.Prefix!.Replace($"{walker.Namespace}.", string.Empty), walker.Members.ToArray());
+                return new LocalisationFile(walker.Namespace!, walker.Name!, walker.Prefix!, walker.Members.ToArray());
             }
         }
 

--- a/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
+++ b/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
@@ -92,7 +92,7 @@ namespace LocalisationAnalyser.Localisation
         /// Generates the syntax for the prefix constant.
         /// </summary>
         public static MemberDeclarationSyntax GeneratePrefixSyntax(LocalisationFile localisationFile)
-            => SyntaxFactory.ParseMemberDeclaration(string.Format(SyntaxTemplates.PREFIX_CONST_TEMPLATE, $"{localisationFile.Namespace}.{localisationFile.Prefix}"))!;
+            => SyntaxFactory.ParseMemberDeclaration(string.Format(SyntaxTemplates.PREFIX_CONST_TEMPLATE, localisationFile.Prefix))!;
 
         /// <summary>
         /// Generates the syntax for the getKey() method.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # osu! Localisation Analyser
 
 This is a .NET analyser providing code fixes to generate localisations for use in [osu!](https://github.com/ppy/osu).
+
+# `.editorconfig` options
+
+```sh
+# Customises the "prefix" namespace value. Defaults to "{AssemblyName}.Localisation".
+dotnet_diagnostic.OLOC001.prefix_namespace = Some.Custom.Namespace
+```


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-localisation-analyser/issues/28
Resolves https://github.com/ppy/osu-localisation-analyser/issues/29

For osu!, we'll move the resource files to osu-resources. This adds an editorconfig option to adjust the "prefix" value, which is currently wired to the namespace of the `Strings` class.

For osu!, this will be set to `dotnet_diagnostic.OLOC001.prefix_namespace = osu.Game.Resources.Localisation`.
It defaults to `{AssemblyName}.Localisation` as previously.

I've also added an `--output` option to the `to-resx` command, in order for the resource files to be easily uploadable to crowdin:
```
[smgi@smgi net5.0]$ ./LocalisationAnalyser.Tools to-resx /home/smgi/Repos/osu/osu.Game/osu.Game.csproj --output ~/Desktop/test
Converting all localisation files in /home/smgi/Repos/osu/osu.Game/osu.Game.csproj...
Processing ButtonSystemStrings.cs...
  -> /home/smgi/Desktop/test/ButtonSystem.resx
Processing ChatStrings.cs...
  -> /home/smgi/Desktop/test/Chat.resx
Processing CommonStrings.cs...
  -> /home/smgi/Desktop/test/Common.resx
Processing NotificationsStrings.cs...
  -> /home/smgi/Desktop/test/Notifications.resx
Processing NowPlayingStrings.cs...
  -> /home/smgi/Desktop/test/NowPlaying.resx
Processing SettingsStrings.cs...
  -> /home/smgi/Desktop/test/Settings.resx
```