### PR TITLE
Workaround Rider bug causing .editorconfigs to not be read

### DIFF
--- a/LocalisationAnalyser.Tests/CodeFixes/AbstractLocaliseStringCodeFixTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/AbstractLocaliseStringCodeFixTests.cs
@@ -14,7 +14,7 @@ namespace LocalisationAnalyser.Tests.CodeFixes
     {
         private const string resources_namespace = "LocalisationAnalyser.Tests.Resources";
 
-        public async Task RunTest(string name)
+        public async Task RunTest(string name, bool brokenAnalyserConfigFiles = false)
         {
             var assembly = Assembly.GetExecutingAssembly();
             var resourceNames = assembly.GetManifestResourceNames();
@@ -41,7 +41,7 @@ namespace LocalisationAnalyser.Tests.CodeFixes
             sourceFiles = sourceFiles.OrderBy(f => Path.GetFileName(f.filename) == "Program.cs" ? -1 : 1).ToList();
             fixedFiles = fixedFiles.OrderBy(f => Path.GetFileName(f.filename) == "Program.cs" ? -1 : 1).ToList();
 
-            await Verify(sourceFiles.ToArray(), fixedFiles.ToArray());
+            await Verify(sourceFiles.ToArray(), fixedFiles.ToArray(), brokenAnalyserConfigFiles);
         }
 
         private string getFileNameFromResourceName(string resourceNamespace, string resourceName)
@@ -58,7 +58,7 @@ namespace LocalisationAnalyser.Tests.CodeFixes
             return new MockFileSystem().Path.GetFullPath(resourceName);
         }
 
-        protected abstract Task Verify((string filename, string content)[] sources, (string filename, string content)[] fixedSources);
+        protected abstract Task Verify((string filename, string content)[] sources, (string filename, string content)[] fixedSources, bool brokenAnalyserConfigFiles = false);
 
         private string readResourceStream(Assembly asm, string resource)
         {

--- a/LocalisationAnalyser.Tests/CodeFixes/LocaliseClassStringCodeFixTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/LocaliseClassStringCodeFixTests.cs
@@ -19,7 +19,11 @@ namespace LocalisationAnalyser.Tests.CodeFixes
         [InlineData("CustomPrefix")]
         public async Task Check(string name) => await RunTest(name);
 
-        protected override Task Verify((string filename, string content)[] sources, (string filename, string content)[] fixedSources)
-            => VerifyCS.VerifyCodeFixAsync(sources, fixedSources);
+        [Theory]
+        [InlineData("CustomPrefix")]
+        public async Task CheckWithBrokenAnalyzerConfigFiles(string name) => await RunTest(name, true);
+
+        protected override Task Verify((string filename, string content)[] sources, (string filename, string content)[] fixedSources, bool brokenAnalyserConfigFiles = false)
+            => VerifyCS.VerifyCodeFixAsync(sources, fixedSources, brokenAnalyserConfigFiles);
     }
 }

--- a/LocalisationAnalyser.Tests/CodeFixes/LocaliseCommonStringCodeFixTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/LocaliseCommonStringCodeFixTests.cs
@@ -15,7 +15,7 @@ namespace LocalisationAnalyser.Tests.CodeFixes
         [InlineData("CommonBasicString")]
         public async Task Check(string name) => await RunTest(name);
 
-        protected override Task Verify((string filename, string content)[] sources, (string filename, string content)[] fixedSources)
+        protected override Task Verify((string filename, string content)[] sources, (string filename, string content)[] fixedSources, bool brokenAnalyserConfigFiles = false)
             => VerifyCS.VerifyCodeFixAsync(sources, fixedSources);
     }
 }

--- a/LocalisationAnalyser.Tests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/LocalisationAnalyser.Tests/Verifiers/CSharpCodeFixVerifier.cs
@@ -14,13 +14,15 @@ namespace LocalisationAnalyser.Tests.Verifiers
         where TAnalyzer : DiagnosticAnalyzer, new()
         where TCodeFix : CodeFixProvider, new()
     {
-        public static async Task VerifyCodeFixAsync((string filename, string contents)[] sources, (string filename, string contents)[] fixedSources)
-            => await VerifyCodeFixAsync(sources, DiagnosticResult.EmptyDiagnosticResults, fixedSources);
+        public static async Task VerifyCodeFixAsync((string filename, string contents)[] sources, (string filename, string contents)[] fixedSources, bool brokenAnalyserConfigFiles = false)
+            => await VerifyCodeFixAsync(sources, DiagnosticResult.EmptyDiagnosticResults, fixedSources, brokenAnalyserConfigFiles);
 
-        public static async Task VerifyCodeFixAsync((string filename, string contents)[] sources, DiagnosticResult expected, (string filename, string contents)[] fixedSources)
-            => await VerifyCodeFixAsync(sources, new[] { expected }, fixedSources);
+        public static async Task VerifyCodeFixAsync((string filename, string contents)[] sources, DiagnosticResult expected, (string filename, string contents)[] fixedSources,
+                                                    bool brokenAnalyserConfigFiles = false)
+            => await VerifyCodeFixAsync(sources, new[] { expected }, fixedSources, brokenAnalyserConfigFiles);
 
-        public static async Task VerifyCodeFixAsync((string filename, string contents)[] sources, DiagnosticResult[] expected, (string filename, string contents)[] fixedSources)
+        public static async Task VerifyCodeFixAsync((string filename, string contents)[] sources, DiagnosticResult[] expected, (string filename, string contents)[] fixedSources,
+                                                    bool brokenAnalyserConfigFiles = false)
         {
             var test = new Test();
 
@@ -32,7 +34,7 @@ namespace LocalisationAnalyser.Tests.Verifiers
                         test.TestState.Sources.Add(s);
                         break;
 
-                    case ".editorconfig":
+                    case ".editorconfig" when !brokenAnalyserConfigFiles:
                         test.TestState.AnalyzerConfigFiles.Add(s);
                         break;
 
@@ -50,7 +52,7 @@ namespace LocalisationAnalyser.Tests.Verifiers
                         test.FixedState.Sources.Add(s);
                         break;
 
-                    case ".editorconfig":
+                    case ".editorconfig" when !brokenAnalyserConfigFiles:
                         test.FixedState.AnalyzerConfigFiles.Add(s);
                         break;
 


### PR DESCRIPTION
Tested in tests and via Rider in the osu! solution.