### PR TITLE
Allow parameters parsed from PHP strings to be localisable

### DIFF
--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -278,7 +278,7 @@ namespace LocalisationAnalyser.Tools
                                 generateMemberNameFromKey(fullKey),
                                 fullKey,
                                 stringValue,
-                                formatParamNames.Select(p => new LocalisationParameter("string", p.Camelize())).ToArray());
+                                formatParamNames.Select(p => new LocalisationParameter("LocalisableString", p.Camelize())).ToArray());
 
                             break;
                     }


### PR DESCRIPTION
Allows for the case mentioned in https://github.com/ppy/osu/issues/13530#issuecomment-864573588 to be possible. Will update osu-resources with this.