### PR TITLE
Extract license header to .editorconfig

### DIFF
--- a/LocalisationAnalyser.Tests/CodeFixes/LocaliseClassStringCodeFixTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/LocaliseClassStringCodeFixTests.cs
@@ -19,6 +19,7 @@ namespace LocalisationAnalyser.Tests.CodeFixes
         [InlineData("CustomPrefix")]
         [InlineData("NestedClass")]
         [InlineData("LongString")]
+        [InlineData("LicenseHeader")]
         public async Task Check(string name) => await RunTest(name);
 
         [Theory]

--- a/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
+++ b/LocalisationAnalyser.Tests/Localisation/LocalisationFileTests.cs
@@ -36,7 +36,7 @@ namespace LocalisationAnalyser.Tests.Localisation
         [Fact]
         public async Task EmptyFileContainsNoMembers()
         {
-            var localisation = await setupFile($@"{SyntaxTemplates.FILE_HEADER_SIGNATURE}
+            var localisation = await setupFile($@"{SyntaxTemplates.FILE_HEADER_TEMPLATE}
 
 namespace {test_namespace}
 {{
@@ -78,7 +78,7 @@ namespace {test_namespace}
             const string key_name = "TestKey";
             const string english_text = "TestEnglish";
 
-            var localisation = await setupFile($@"{SyntaxTemplates.FILE_HEADER_SIGNATURE}
+            var localisation = await setupFile($@"{SyntaxTemplates.FILE_HEADER_TEMPLATE}
 
 namespace {test_namespace}
 {{
@@ -134,7 +134,7 @@ namespace {test_namespace}
             var param2 = new LocalisationParameter("string", "second");
             var param3 = new LocalisationParameter("customobj", "third");
 
-            var localisation = await setupFile($@"{SyntaxTemplates.FILE_HEADER_SIGNATURE}
+            var localisation = await setupFile($@"{SyntaxTemplates.FILE_HEADER_TEMPLATE}
 
 namespace {test_namespace}
 {{
@@ -168,7 +168,7 @@ namespace {test_namespace}
             const string prop_name = "TestProperty";
             const string key_name = "TestKey";
 
-            var localisation = await setupFile($@"{SyntaxTemplates.FILE_HEADER_SIGNATURE}
+            var localisation = await setupFile($@"{SyntaxTemplates.FILE_HEADER_TEMPLATE}
 
 namespace {test_namespace}
 {{
@@ -285,7 +285,7 @@ namespace {test_namespace}
         {
             var sb = new StringBuilder();
 
-            sb.Append($@"{SyntaxTemplates.FILE_HEADER_SIGNATURE}
+            sb.Append($@"{string.Format(SyntaxTemplates.FILE_HEADER_TEMPLATE, string.Empty)}
 
 namespace {test_namespace}
 {{

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/BasicString/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/BasicString/Fixed/Localisation/ProgramStrings.txt
@@ -1,6 +1,3 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using osu.Framework.Localisation;
 
 namespace TestProject.Localisation

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/CustomPrefix/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/CustomPrefix/Fixed/Localisation/ProgramStrings.txt
@@ -1,6 +1,3 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using osu.Framework.Localisation;
 
 namespace TestProject.Localisation

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/InterpolatedString/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/InterpolatedString/Fixed/Localisation/ProgramStrings.txt
@@ -1,6 +1,3 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using osu.Framework.Localisation;
 
 namespace TestProject.Localisation

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/InterpolatedStringWithQuotes/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/InterpolatedStringWithQuotes/Fixed/Localisation/ProgramStrings.txt
@@ -1,6 +1,3 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using osu.Framework.Localisation;
 
 namespace TestProject.Localisation

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/LicenseHeader/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/LicenseHeader/Fixed/Localisation/ProgramStrings.txt
@@ -1,10 +1,13 @@
+// This is a custom license header
+// This is line 2
+
 using osu.Framework.Localisation;
 
 namespace TestProject.Localisation
 {
-    public static class CommonStrings
+    public static class ProgramStrings
     {
-        private const string prefix = @"TestProject.Localisation.Common";
+        private const string prefix = @"TestProject.Localisation.Program";
 
         /// <summary>
         /// "abc"

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/LicenseHeader/Fixed/Program.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/LicenseHeader/Fixed/Program.txt
@@ -1,0 +1,12 @@
+using TestProject.Localisation;
+
+namespace Test
+{
+    class Program
+    {
+        static void Main()
+        {
+            string x = ProgramStrings.Abc;
+        }
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/LicenseHeader/Sources/.editorconfig
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/LicenseHeader/Sources/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.cs]
+dotnet_diagnostic.OLOC001.license_header = // This is a custom license header\n// This is line 2

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/LicenseHeader/Sources/Program.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/LicenseHeader/Sources/Program.txt
@@ -1,0 +1,10 @@
+namespace Test
+{
+    class Program
+    {
+        static void Main()
+        {
+            string x = [|"abc"|];
+        }
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/LongString/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/LongString/Fixed/Localisation/ProgramStrings.txt
@@ -1,6 +1,3 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using osu.Framework.Localisation;
 
 namespace TestProject.Localisation

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/LongStringWithLimitedWordsInName/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/LongStringWithLimitedWordsInName/Fixed/Localisation/ProgramStrings.txt
@@ -1,6 +1,3 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using osu.Framework.Localisation;
 
 namespace TestProject.Localisation

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/NestedClass/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/NestedClass/Fixed/Localisation/ProgramStrings.txt
@@ -1,6 +1,3 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using osu.Framework.Localisation;
 
 namespace TestProject.Localisation

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/VerbatimString/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/VerbatimString/Fixed/Localisation/ProgramStrings.txt
@@ -1,6 +1,3 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using osu.Framework.Localisation;
 
 namespace TestProject.Localisation

--- a/LocalisationAnalyser.Tools/OsuAnalyzerConfigOptions.cs
+++ b/LocalisationAnalyser.Tools/OsuAnalyzerConfigOptions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace LocalisationAnalyser.Tools
+{
+    public class OsuAnalyzerConfigOptions : AnalyzerConfigOptions
+    {
+        public override bool TryGetValue(string key, out string value)
+        {
+            // License header is hard-coded for now as the tool is meant for internal osu! usage only.
+            if (key == $"dotnet_diagnostic.{DiagnosticRules.STRING_CAN_BE_LOCALISED.Id}.license_header")
+            {
+                value = "// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.\n// See the LICENCE file in the repository root for full licence text.";
+                return true;
+            }
+
+            value = string.Empty;
+            return false;
+        }
+    }
+}

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -189,7 +189,7 @@ namespace LocalisationAnalyser.Tools
             {
                 var localisationFile = new LocalisationFile(nameSpace, Path.GetFileNameWithoutExtension(targetLocalisationFile), $"{nameSpace}.{name}", members);
                 using (var fs = File.Open(targetLocalisationFile, FileMode.Create, FileAccess.ReadWrite))
-                    await localisationFile.WriteAsync(fs, new AdhocWorkspace());
+                    await localisationFile.WriteAsync(fs, new AdhocWorkspace(), new OsuAnalyzerConfigOptions());
 
                 Console.WriteLine($"  -> {targetLocalisationFile}");
             }

--- a/LocalisationAnalyser/Localisation/LocalisationFile.cs
+++ b/LocalisationAnalyser/Localisation/LocalisationFile.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace LocalisationAnalyser.Localisation
@@ -57,10 +58,11 @@ namespace LocalisationAnalyser.Localisation
         /// </summary>
         /// <param name="stream">The stream to write to.</param>
         /// <param name="workspace">The workspace to format with.</param>
-        public async Task WriteAsync(Stream stream, Workspace workspace)
+        /// <param name="options">The analyser options to apply to the document.</param>
+        public async Task WriteAsync(Stream stream, Workspace workspace, AnalyzerConfigOptions? options = null)
         {
             using (var sw = new StreamWriter(stream))
-                await sw.WriteAsync(Formatter.Format(SyntaxGenerators.GenerateClassSyntax(workspace, this), workspace).ToFullString());
+                await sw.WriteAsync(Formatter.Format(SyntaxGenerators.GenerateClassSyntax(workspace, this, options), workspace).ToFullString());
         }
 
         /// <summary>

--- a/LocalisationAnalyser/Localisation/SyntaxTemplates.cs
+++ b/LocalisationAnalyser/Localisation/SyntaxTemplates.cs
@@ -83,19 +83,9 @@ public static {MEMBER_RETURN_TYPE} {{0}}{{1}} => new {MEMBER_CONSTRUCTION_TYPE}(
 private static string {GET_KEY_METHOD_NAME}(string key) => $@""{{prefix}}:{{key}}"";";
 
         /// <summary>
-        /// The license header.
-        /// </summary>
-        public const string LICENSE_HEADER =
-            @"// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.";
-
-        /// <summary>
         /// The template for the localisation file header.
         /// </summary>
-        public static readonly string FILE_HEADER_SIGNATURE =
-            @$"{LICENSE_HEADER}
-
-using osu.Framework.Localisation;";
+        public const string FILE_HEADER_TEMPLATE = @"{0}using osu.Framework.Localisation;";
 
         /// <summary>
         /// The suffix attached to a localisation file name.

--- a/LocalisationAnalyser/Utils/DocumentUtils.cs
+++ b/LocalisationAnalyser/Utils/DocumentUtils.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace LocalisationAnalyser.Utils
+{
+    public static class DocumentUtils
+    {
+        public static async Task<AnalyzerConfigOptions> GetAnalyserOptionsAsync(this Document document, CancellationToken cancellationToken)
+        {
+            var project = document.Project;
+
+            var analyzersInAdditionalDocuments = project.AdditionalDocuments
+                                                        .Where(d => d.FilePath.EndsWith(".editorconfig"))
+                                                        .Select(d => d.Id);
+
+            // Rider <= 2021.2 EAP5 puts analyzer configs in the incorrect location (project.AdditionalDocuments rather than the expected project.AnalyzerConfigDocuments).
+            // We need to manually duplicate these files into AnalyzerConfigDocuments to allow the analyser to read the file.
+            // Note that, also due to Rider, this only handles the project's .editorconfig file.
+            // Todo: Remove when https://youtrack.jetbrains.com/issue/RIDER-64877 is fixed!!
+            foreach (var docId in analyzersInAdditionalDocuments)
+            {
+                var doc = project.GetAdditionalDocument(docId);
+                var text = await doc!.GetTextAsync(cancellationToken);
+                project = project.AddAnalyzerConfigDocument(doc.Name, text, doc.Folders, doc.FilePath).Project;
+            }
+
+            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var options = project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(tree);
+            return options;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -10,4 +10,7 @@ dotnet_diagnostic.OLOC001.prefix_namespace = Some.Custom.Namespace
 
 # The number of words to use in the source string to generate the target member name. Defaults to all words in the string.
 dotnet_diagnostic.OLOC001.words_in_name = 5
+
+# The license header to prepend to the start of the "Strings" classes.
+dotnet_diagnostic.OLOC001.license_header = // Line 1 of license header\n// Line 2 of license header
 ```


### PR DESCRIPTION
Hard-coding the ppy license header is bad because others want to use this tool for themselves.
```
dotnet_diagnostic.OLOC001.license_header = ...
```

It's still hard-coded in the dotnet-tool because it's only supposed to be used by osu!/in connection with osu-web.