### PR TITLE
Attempt to fix code fixes changing order randomly

### DIFF
--- a/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
@@ -57,7 +57,7 @@ namespace LocalisationAnalyser.CodeFixes
                         new LocaliseStringCodeAction(
                             $"Use existing {friendlyLocalisationTarget} localisation: {matchingMember.Name}",
                             (preview, cancellationToken) => localiseLiteralAsync(context.Document, literal, preview, cancellationToken, true),
-                            nameof(LocaliseClassStringCodeFixProvider)),
+                            $@"{friendlyLocalisationTarget}-existing-literal"),
                         diagnostic);
                 }
                 else
@@ -66,7 +66,7 @@ namespace LocalisationAnalyser.CodeFixes
                         new LocaliseStringCodeAction(
                             $"Add new {friendlyLocalisationTarget} localisation for: {literal}",
                             (preview, cancellationToken) => localiseLiteralAsync(context.Document, literal, preview, cancellationToken, false),
-                            nameof(LocaliseClassStringCodeFixProvider)),
+                            $@"{friendlyLocalisationTarget}-new-literal"),
                         diagnostic);
                 }
             }
@@ -77,7 +77,7 @@ namespace LocalisationAnalyser.CodeFixes
                     new LocaliseStringCodeAction(
                         $"Add new {friendlyLocalisationTarget} localisation for: {interpolated}",
                         (preview, cancellationToken) => localiseInterpolatedStringAsync(context.Document, interpolated, preview, cancellationToken),
-                        nameof(LocaliseClassStringCodeFixProvider)),
+                        $@"{friendlyLocalisationTarget}-new-interpolated"),
                     diagnostic);
             }
         }

--- a/LocalisationAnalyser/CodeFixes/LocaliseCommonStringCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/LocaliseCommonStringCodeFixProvider.cs
@@ -14,6 +14,7 @@ namespace LocalisationAnalyser.CodeFixes
     /// Code-fix provider for <see cref="DiagnosticRules.STRING_CAN_BE_LOCALISED"/> inspections to replace strings with a localisation from the common localisation class.
     /// </summary>
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LocaliseCommonStringCodeFixProvider)), Shared]
+    [ExtensionOrder(After = nameof(LocaliseClassStringCodeFixProvider))]
     internal class LocaliseCommonStringCodeFixProvider : AbstractLocaliseStringCodeFixProvider
     {
         public LocaliseCommonStringCodeFixProvider()


### PR DESCRIPTION
Bit of a shot in the dark, especially since I can't seem to repro this. I also can't find any documentation on this attribute but I'm seeing whisperings of it around the place:
https://github.com/dotnet/roslyn/blob/41fa23e17b30659610a2b257155b688cd4f5ac9a/src/Analyzers/CSharp/CodeFixes/QualifyMemberAccess/CSharpQualifyMemberAccessCodeFixProvider.cs#L15-L16

If this doesn't work, I think the next step is to merge the two classes into one, though that doesn't look like an easy change to make.