### PR TITLE
Refactor and improve support for more situations

### DIFF
--- a/LocalisationAnalyser.Tests/Analysers/AbstractAnalyserTests.cs
+++ b/LocalisationAnalyser.Tests/Analysers/AbstractAnalyserTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using LocalisationAnalyser.Tests.Helpers.IO;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace LocalisationAnalyser.Tests.Analysers
+{
+    public abstract class AbstractAnalyserTests<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        private const string resources_namespace = "LocalisationAnalyser.Tests.Resources";
+
+        protected async Task Check(string name)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var resourceNames = assembly.GetManifestResourceNames();
+
+            var sourceFiles = new List<string>
+            {
+                $"{resources_namespace}.LocalisableString.txt",
+                $"{resources_namespace}.TranslatableString.txt",
+            };
+
+            foreach (var f in resourceNames.Where(n => n.StartsWith($"{resources_namespace}.Analysers.{name}")))
+                sourceFiles.Add(f);
+
+            await Verifiers.CSharpAnalyzerVerifier<TAnalyzer>.VerifyAnalyzerAsync(
+                sourceFiles.Select(f => (getFileNameFromResourceName($"{resources_namespace}.Analysers.{name}", f), readResourceStream(assembly, f))).ToArray());
+        }
+
+        private string getFileNameFromResourceName(string resourceNamespace, string resourceName)
+        {
+            string extension = Path.GetExtension(resourceName);
+
+            resourceName = resourceName.Replace(resourceNamespace, string.Empty)[1..]
+                                       .Replace(extension, string.Empty)
+                                       .Replace('.', '/');
+
+            // .txt files are converted to .cs.
+            resourceName = extension == ".txt" ? $"{resourceName}.cs" : $"{resourceName}{extension}";
+
+            return new MockFileSystem().Path.GetFullPath(resourceName);
+        }
+
+        private string readResourceStream(Assembly asm, string resource)
+        {
+            using (var stream = asm.GetManifestResourceStream(resource)!)
+            using (var sr = new StreamReader(stream))
+                return sr.ReadToEnd();
+        }
+    }
+}

--- a/LocalisationAnalyser.Tests/Analysers/StringCanBeLocalisedAnalyserTests.cs
+++ b/LocalisationAnalyser.Tests/Analysers/StringCanBeLocalisedAnalyserTests.cs
@@ -1,20 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
+using LocalisationAnalyser.Analysers;
 using Xunit;
-using Verify = LocalisationAnalyser.Tests.Verifiers.CSharpAnalyzerVerifier<LocalisationAnalyser.Analysers.StringCanBeLocalisedAnalyser>;
 
 namespace LocalisationAnalyser.Tests.Analysers
 {
-    public class StringCanBeLocalisedAnalyserTests
+    public class StringCanBeLocalisedAnalyserTests : AbstractAnalyserTests<StringCanBeLocalisedAnalyser>
     {
-        private const string resources_namespace = "LocalisationAnalyser.Tests.Resources";
-
         [Theory]
         [InlineData("Attribute")]
         [InlineData("DescriptionAttribute")]
@@ -25,28 +19,6 @@ namespace LocalisationAnalyser.Tests.Analysers
         [InlineData("StringConcatenation")]
         [InlineData("VerbatimString")]
         [InlineData("VerbatimInterpolatedString")]
-        public async Task Check(string name)
-        {
-            var assembly = Assembly.GetExecutingAssembly();
-            var resourceNames = assembly.GetManifestResourceNames();
-
-            var sourceFiles = new List<string>
-            {
-                $"{resources_namespace}.LocalisableString.txt",
-                $"{resources_namespace}.TranslatableString.txt",
-            };
-
-            foreach (var f in resourceNames.Where(n => n.StartsWith($"{resources_namespace}.Analysers.{name}")))
-                sourceFiles.Add(f);
-
-            await Verify.VerifyAnalyzerAsync(sourceFiles.Select(f => readResourceStream(assembly, f)).ToArray());
-        }
-
-        private string readResourceStream(Assembly asm, string resource)
-        {
-            using (var stream = asm.GetManifestResourceStream(resource)!)
-            using (var sr = new StreamReader(stream))
-                return sr.ReadToEnd();
-        }
+        public Task RunTest(string name) => Check(name);
     }
 }

--- a/LocalisationAnalyser.Tests/CodeFixes/AbstractCodeFixProviderTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/AbstractCodeFixProviderTests.cs
@@ -10,7 +10,7 @@ using LocalisationAnalyser.Tests.Helpers.IO;
 
 namespace LocalisationAnalyser.Tests.CodeFixes
 {
-    public abstract class AbstractLocaliseStringCodeFixTests
+    public abstract class AbstractCodeFixProviderTests
     {
         private const string resources_namespace = "LocalisationAnalyser.Tests.Resources";
 

--- a/LocalisationAnalyser.Tests/CodeFixes/LocaliseClassStringCodeFixProviderTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/LocaliseClassStringCodeFixProviderTests.cs
@@ -9,7 +9,7 @@ using VerifyCS = LocalisationAnalyser.Tests.Verifiers.CSharpCodeFixVerifier<
 
 namespace LocalisationAnalyser.Tests.CodeFixes
 {
-    public class LocaliseClassStringCodeFixTests : AbstractLocaliseStringCodeFixTests
+    public class LocaliseClassStringCodeFixProviderTests : AbstractCodeFixProviderTests
     {
         [Theory]
         [InlineData("BasicString")]

--- a/LocalisationAnalyser.Tests/CodeFixes/LocaliseCommonStringCodeFixProviderTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/LocaliseCommonStringCodeFixProviderTests.cs
@@ -9,7 +9,7 @@ using VerifyCS = LocalisationAnalyser.Tests.Verifiers.CSharpCodeFixVerifier<
 
 namespace LocalisationAnalyser.Tests.CodeFixes
 {
-    public class LocaliseCommonStringCodeFixTests : AbstractLocaliseStringCodeFixTests
+    public class LocaliseCommonStringCodeFixProviderTests : AbstractCodeFixProviderTests
     {
         [Theory]
         [InlineData("CommonBasicString")]

--- a/LocalisationAnalyser.Tests/Verifiers/CSharpAnalyzerVerifier.cs
+++ b/LocalisationAnalyser.Tests/Verifiers/CSharpAnalyzerVerifier.cs
@@ -23,7 +23,7 @@ namespace LocalisationAnalyser.Tests.Verifiers
         public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
             => CSharpAnalyzerVerifier<TAnalyzer, XUnitVerifier>.Diagnostic(descriptor);
 
-        public static async Task VerifyAnalyzerAsync(string[] sources, params DiagnosticResult[] expected)
+        public static async Task VerifyAnalyzerAsync((string filename, string content)[] sources, params DiagnosticResult[] expected)
         {
             var test = new Test();
 

--- a/LocalisationAnalyser.Tests/Verifiers/CSharpAnalyzerVerifier.cs
+++ b/LocalisationAnalyser.Tests/Verifiers/CSharpAnalyzerVerifier.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -8,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Text;
 
 namespace LocalisationAnalyser.Tests.Verifiers
 {
@@ -28,7 +30,7 @@ namespace LocalisationAnalyser.Tests.Verifiers
             var test = new Test();
 
             foreach (var s in sources)
-                test.TestState.Sources.Add(s);
+                test.TestState.Sources.Add((s.filename, SourceText.From(s.content, Encoding.UTF8)));
 
             test.ExpectedDiagnostics.AddRange(expected);
             await test.RunAsync(CancellationToken.None);

--- a/LocalisationAnalyser.Tests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/LocalisationAnalyser.Tests/Verifiers/CSharpCodeFixVerifier.cs
@@ -2,11 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
 
 namespace LocalisationAnalyser.Tests.Verifiers
 {
@@ -31,7 +33,7 @@ namespace LocalisationAnalyser.Tests.Verifiers
                 switch (Path.GetExtension(s.filename))
                 {
                     case ".cs":
-                        test.TestState.Sources.Add(s);
+                        test.TestState.Sources.Add((s.filename, SourceText.From(s.contents, Encoding.UTF8)));
                         break;
 
                     case ".editorconfig" when !brokenAnalyserConfigFiles:
@@ -49,7 +51,7 @@ namespace LocalisationAnalyser.Tests.Verifiers
                 switch (Path.GetExtension(s.filename))
                 {
                     case ".cs":
-                        test.FixedState.Sources.Add(s);
+                        test.FixedState.Sources.Add((s.filename, SourceText.From(s.contents, Encoding.UTF8)));
                         break;
 
                     case ".editorconfig" when !brokenAnalyserConfigFiles:

--- a/LocalisationAnalyser/Analysers/StringCanBeLocalisedAnalyser.cs
+++ b/LocalisationAnalyser/Analysers/StringCanBeLocalisedAnalyser.cs
@@ -15,7 +15,7 @@ namespace LocalisationAnalyser.Analysers
     /// Discovers all non-verbatim strings (literal and interpolated) and reports <see cref="DiagnosticRules.STRING_CAN_BE_LOCALISED"/>.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    internal class StringCanBeLocalisedAnalyser : DiagnosticAnalyzer
+    public class StringCanBeLocalisedAnalyser : DiagnosticAnalyzer
     {
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticRules.STRING_CAN_BE_LOCALISED);
 

--- a/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 
 namespace LocalisationAnalyser.CodeFixes
 {
@@ -204,7 +205,7 @@ namespace LocalisationAnalyser.CodeFixes
                     {
                         var classDocument = project.AddDocument(
                             file.FullName,
-                            file.FileSystem.File.ReadAllText(file.FullName),
+                            SourceText.From(file.FileSystem.File.ReadAllText(file.FullName), Encoding.UTF8),
                             Enumerable.Empty<string>(),
                             file.FullName);
 

--- a/LocalisationAnalyser/Localisation/LocalisationMember.cs
+++ b/LocalisationAnalyser/Localisation/LocalisationMember.cs
@@ -27,6 +27,14 @@ namespace LocalisationAnalyser.Localisation
         public readonly string EnglishText;
 
         /// <summary>
+        /// The XMLDoc for this member. Usually matches <see cref="EnglishText"/>.
+        /// </summary>
+        /// <remarks>
+        /// This value is not XML-encoded.
+        /// </remarks>
+        public readonly string XmlDoc;
+
+        /// <summary>
         /// Any parameters. If this is non-empty, the <see cref="LocalisationMember"/> represents a method.
         /// </summary>
         public readonly ImmutableArray<LocalisationParameter> Parameters;
@@ -39,10 +47,25 @@ namespace LocalisationAnalyser.Localisation
         /// <param name="englishText">The english default text. This is also used for the XMLDoc.</param>
         /// <param name="parameters">Any parameters. If this is non-empty, the <see cref="LocalisationMember"/> will represent a method.</param>
         public LocalisationMember(string name, string key, string englishText, params LocalisationParameter[] parameters)
+            : this(name, key, englishText, englishText, parameters)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="LocalisationMember"/>.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="key">The localisation key to use for lookups.</param>
+        /// <param name="englishText">The english default text. This is also used for the XMLDoc.</param>
+        /// <param name="xmlDoc">The XMLDoc for this member. Usually matches <paramref name="englishText"/> but may be provided separately.
+        /// Must not be XML-encoded.</param>
+        /// <param name="parameters">Any parameters. If this is non-empty, the <see cref="LocalisationMember"/> will represent a method.</param>
+        public LocalisationMember(string name, string key, string englishText, string xmlDoc, params LocalisationParameter[] parameters)
         {
             Name = name;
             Key = key;
             EnglishText = englishText;
+            XmlDoc = xmlDoc;
             Parameters = parameters.ToImmutableArray();
         }
 
@@ -51,7 +74,7 @@ namespace LocalisationAnalyser.Localisation
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Name == other.Name && Key == other.Key && EnglishText == other.EnglishText && Parameters.Equals(other.Parameters);
+            return Name == other.Name && Key == other.Key && EnglishText == other.EnglishText && XmlDoc == other.XmlDoc && Parameters.Equals(other.Parameters);
         }
 
         public override bool Equals(object? obj)
@@ -70,6 +93,7 @@ namespace LocalisationAnalyser.Localisation
                 var hashCode = Name.GetHashCode();
                 hashCode = (hashCode * 397) ^ Key.GetHashCode();
                 hashCode = (hashCode * 397) ^ EnglishText.GetHashCode();
+                hashCode = (hashCode * 397) ^ XmlDoc.GetHashCode();
                 hashCode = (hashCode * 397) ^ Parameters.GetHashCode();
                 return hashCode;
             }

--- a/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
+++ b/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
@@ -75,7 +75,7 @@ namespace LocalisationAnalyser.Localisation
                     member.Name,
                     member.Key,
                     convertToVerbatim(member.EnglishText),
-                    EncodeXmlDoc(member.EnglishText)))!;
+                    EncodeXmlDoc(member.XmlDoc)))!;
 
         /// <summary>
         /// Generates the syntax for a method member.
@@ -101,7 +101,7 @@ namespace LocalisationAnalyser.Localisation
                     member.Key,
                     convertToVerbatim(member.EnglishText),
                     trimParens(Formatter.Format(argList, workspace).ToFullString()), // The entire string minus the parens
-                    EncodeXmlDoc(member.EnglishText)))!;
+                    EncodeXmlDoc(member.XmlDoc)))!;
 
             static string trimParens(string input) => input.Substring(1, input.Length - 2);
         }
@@ -202,9 +202,9 @@ namespace LocalisationAnalyser.Localisation
                 SyntaxFactory.ParseName(directive)));
         }
 
-        public static string EncodeXmlDoc(string xmlDoc)
+        public static string EncodeXmlDoc(string text)
         {
-            var lines = xmlDoc.Split('\n');
+            var lines = text.Split('\n');
 
             for (int i = 0; i < lines.Length; i++)
             {
@@ -224,6 +224,19 @@ namespace LocalisationAnalyser.Localisation
             }
 
             return string.Join(Environment.NewLine, lines);
+        }
+
+        public static string DecodeXmlDoc(string xmlDoc)
+        {
+            xmlDoc = xmlDoc.Trim();
+
+            // A valid XMLDoc is formulated as: "text". We need to remove only one set of quotes from either side, so Trim() is too greedy.
+            if (xmlDoc.Length > 0)
+                xmlDoc = xmlDoc.Substring(1);
+            if (xmlDoc.Length > 0)
+                xmlDoc = xmlDoc.Substring(0, xmlDoc.Length - 1);
+
+            return HttpUtility.HtmlDecode(xmlDoc);
         }
 
         /// <summary>


### PR DESCRIPTION
- Adds/renames abstract test classes so other usages can derive them.
- Normalises input/output to UTF8.
- Adds more overloads for reading `LocalisationFile`s. I ended up not needing a majority of these anymore, but the most important one is the synchronous `SourceText` override.
- Adds ability to read/write xmldoc for `LocalisationMember`s separately from the "english text" (translation text).