### PR TITLE
Add initial analyser + codefix for when xmldoc and text don't match

### DIFF
--- a/LocalisationAnalyser.Tests/Analysers/TextDoesNotMatchXmlDocAnalyserTests.cs
+++ b/LocalisationAnalyser.Tests/Analysers/TextDoesNotMatchXmlDocAnalyserTests.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using LocalisationAnalyser.Analysers;
+using Xunit;
+
+namespace LocalisationAnalyser.Tests.Analysers
+{
+    public class TextDoesNotMatchXmlDocAnalyserTests : AbstractAnalyserTests<TextDoesNotMatchXmlDocAnalyser>
+    {
+        [Theory]
+        [InlineData("TextDoesNotMatchXmlDoc")]
+        public Task RunTest(string name) => Check(name);
+    }
+}

--- a/LocalisationAnalyser.Tests/Analysers/XmlDocDoesNotMatchTextAnalyserTests.cs
+++ b/LocalisationAnalyser.Tests/Analysers/XmlDocDoesNotMatchTextAnalyserTests.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using LocalisationAnalyser.Analysers;
+using Xunit;
+
+namespace LocalisationAnalyser.Tests.Analysers
+{
+    public class XmlDocDoesNotMatchTextAnalyserTests : AbstractAnalyserTests<XmlDocDoesNotMatchTextAnalyser>
+    {
+        [Theory]
+        [InlineData("XmlDocDoesNotMatchText")]
+        public Task RunTest(string name) => Check(name);
+    }
+}

--- a/LocalisationAnalyser.Tests/CodeFixes/MakeTextMatchXmlDocCodeFixProviderTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/MakeTextMatchXmlDocCodeFixProviderTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using Xunit;
+using VerifyCS = LocalisationAnalyser.Tests.Verifiers.CSharpCodeFixVerifier<
+    LocalisationAnalyser.Analysers.TextDoesNotMatchXmlDocAnalyser,
+    LocalisationAnalyser.CodeFixes.MakeTextMatchXmlDocCodeFixProvider>;
+
+namespace LocalisationAnalyser.Tests.CodeFixes
+{
+    public class MakeTextMatchXmlDocCodeFixProviderTests : AbstractCodeFixProviderTests
+    {
+        [Theory]
+        [InlineData("MakeTextMatchXmlDoc")]
+        public async Task Check(string name) => await RunTest(name);
+
+        protected override Task Verify((string filename, string content)[] sources, (string filename, string content)[] fixedSources, bool brokenAnalyserConfigFiles = false)
+            => VerifyCS.VerifyCodeFixAsync(sources, fixedSources);
+    }
+}

--- a/LocalisationAnalyser.Tests/CodeFixes/MakeXmlDocMatchTextCodeFixProviderTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/MakeXmlDocMatchTextCodeFixProviderTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using Xunit;
+using VerifyCS = LocalisationAnalyser.Tests.Verifiers.CSharpCodeFixVerifier<
+    LocalisationAnalyser.Analysers.XmlDocDoesNotMatchTextAnalyser,
+    LocalisationAnalyser.CodeFixes.MakeXmlDocMatchTextCodeFixProvider>;
+
+namespace LocalisationAnalyser.Tests.CodeFixes
+{
+    public class MakeXmlDocMatchTextCodeFixProviderTests : AbstractCodeFixProviderTests
+    {
+        [Theory]
+        [InlineData("MakeXmlDocMatchText")]
+        public async Task Check(string name) => await RunTest(name);
+
+        protected override Task Verify((string filename, string content)[] sources, (string filename, string content)[] fixedSources, bool brokenAnalyserConfigFiles = false)
+            => VerifyCS.VerifyCodeFixAsync(sources, fixedSources);
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/Analysers/TextDoesNotMatchXmlDoc/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/Analysers/TextDoesNotMatchXmlDoc/Localisation/CommonStrings.txt
@@ -1,0 +1,31 @@
+using osu.Framework.Localisation;
+
+namespace TestProject.Localisation
+{
+    public static class CommonStrings
+    {
+        private const string prefix = @"TestProject.Localisation.Common";
+
+        /// <summary>
+        /// "matches"
+        /// </summary>
+        public static LocalisableString Matches => new TranslatableString(getKey(@"matches"), @"matches");
+
+        /// <summary>
+        /// "does not match"
+        /// </summary>
+        public static LocalisableString DoesNotMatch => new TranslatableString(getKey(@"does_not_match"), [|@"dnm"|]);
+
+        /// <summary>
+        /// ""&lt;&gt;?&quot;&#39;&#39;&amp;*!@#&amp;*^%^()-=""
+        /// </summary>
+        public static LocalisableString SpecialChars => new TranslatableString(getKey(@"special_chars"), @"""<>?""''&*!@#&*^%^()-=""");
+
+        /// <summary>
+        /// ""&lt;&gt;?&quot;&#39;&#39;&amp;*!@#&amp;*^%^()-=""
+        /// </summary>
+        public static LocalisableString SpecialCharsDoNotMatch => new TranslatableString(getKey(@"special_chars"), [|@"<>?""''&*!@#&*^%^()-="|]);
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/Analysers/XmlDocDoesNotMatchText/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/Analysers/XmlDocDoesNotMatchText/Localisation/CommonStrings.txt
@@ -1,0 +1,31 @@
+using osu.Framework.Localisation;
+
+namespace TestProject.Localisation
+{
+    public static class CommonStrings
+    {
+        private const string prefix = @"TestProject.Localisation.Common";
+
+        /// <summary>
+        /// "matches"
+        /// </summary>
+        public static LocalisableString Matches => new TranslatableString(getKey(@"matches"), @"matches");
+
+        ///[| <summary>
+        /// "does not match"
+        /// </summary>
+|]        public static LocalisableString DoesNotMatch => new TranslatableString(getKey(@"does_not_match"), @"dnm");
+
+        /// <summary>
+        /// ""&lt;&gt;?&quot;&#39;&#39;&amp;*!@#&amp;*^%^()-=""
+        /// </summary>
+        public static LocalisableString SpecialChars => new TranslatableString(getKey(@"special_chars"), @"""<>?""''&*!@#&*^%^()-=""");
+
+        ///[| <summary>
+        /// ""&lt;&gt;?&quot;&#39;&#39;&amp;*!@#&amp;*^%^()-=""
+        /// </summary>
+|]        public static LocalisableString SpecialCharsDoNotMatch => new TranslatableString(getKey(@"special_chars"), @"<>?""''&*!@#&*^%^()-=");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeTextMatchXmlDoc/Fixed/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeTextMatchXmlDoc/Fixed/Localisation/CommonStrings.txt
@@ -1,0 +1,16 @@
+using osu.Framework.Localisation;
+
+namespace TestProject.Localisation
+{
+    public static class CommonStrings
+    {
+        private const string prefix = @"TestProject.Localisation.Common";
+
+        /// <summary>
+        /// "does not match"
+        /// </summary>
+        public static LocalisableString DoesNotMatch => new TranslatableString(getKey(@"does_not_match"), @"does not match");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeTextMatchXmlDoc/Sources/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeTextMatchXmlDoc/Sources/Localisation/CommonStrings.txt
@@ -1,0 +1,16 @@
+using osu.Framework.Localisation;
+
+namespace TestProject.Localisation
+{
+    public static class CommonStrings
+    {
+        private const string prefix = @"TestProject.Localisation.Common";
+
+        /// <summary>
+        /// "does not match"
+        /// </summary>
+        public static LocalisableString DoesNotMatch => new TranslatableString(getKey(@"does_not_match"), [|@"dnm"|]);
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeXmlDocMatchText/Fixed/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeXmlDocMatchText/Fixed/Localisation/CommonStrings.txt
@@ -1,0 +1,16 @@
+using osu.Framework.Localisation;
+
+namespace TestProject.Localisation
+{
+    public static class CommonStrings
+    {
+        private const string prefix = @"TestProject.Localisation.Common";
+
+        /// <summary>
+        /// "dnm"
+        /// </summary>
+        public static LocalisableString DoesNotMatch => new TranslatableString(getKey(@"does_not_match"), @"dnm");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeXmlDocMatchText/Sources/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeXmlDocMatchText/Sources/Localisation/CommonStrings.txt
@@ -1,0 +1,16 @@
+using osu.Framework.Localisation;
+
+namespace TestProject.Localisation
+{
+    public static class CommonStrings
+    {
+        private const string prefix = @"TestProject.Localisation.Common";
+
+        ///[| <summary>
+        /// "does not match"
+        /// </summary>
+|]        public static LocalisableString DoesNotMatch => new TranslatableString(getKey(@"does_not_match"), @"dnm");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/LocalisationAnalyser/Analysers/AbstractMemberAnalyser.cs
+++ b/LocalisationAnalyser/Analysers/AbstractMemberAnalyser.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using LocalisationAnalyser.Localisation;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace LocalisationAnalyser.Analysers
+{
+    public abstract class AbstractMemberAnalyser : DiagnosticAnalyzer
+    {
+        public override void Initialize(AnalysisContext context)
+        {
+            // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Analyzer%20Actions%20Semantics.md for more information
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxTreeAction(analyseSyntaxTree);
+        }
+
+        private void analyseSyntaxTree(SyntaxTreeAnalysisContext context)
+        {
+            // Optimisation to not inspect too many files.
+            if (!context.Tree.FilePath.EndsWith("Strings.cs"))
+                return;
+
+            if (!LocalisationFile.TryRead(context.Tree, out var file, out _))
+                return;
+
+            var root = context.Tree.GetRoot();
+
+            foreach (var prop in root.DescendantNodes().OfType<PropertyDeclarationSyntax>())
+                AnalyseProperty(context, prop, file);
+        }
+
+        protected virtual void AnalyseProperty(SyntaxTreeAnalysisContext context, PropertyDeclarationSyntax property, LocalisationFile localisationFile)
+        {
+        }
+    }
+}

--- a/LocalisationAnalyser/Analysers/TextDoesNotMatchXmlDocAnalyser.cs
+++ b/LocalisationAnalyser/Analysers/TextDoesNotMatchXmlDocAnalyser.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Immutable;
+using System.Linq;
+using LocalisationAnalyser.Localisation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace LocalisationAnalyser.Analysers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class TextDoesNotMatchXmlDocAnalyser : AbstractMemberAnalyser
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticRules.TEXT_DOES_NOT_MATCH_XMLDOC);
+
+        protected override void AnalyseProperty(SyntaxTreeAnalysisContext context, PropertyDeclarationSyntax property, LocalisationFile localisationFile)
+        {
+            base.AnalyseProperty(context, property, localisationFile);
+
+            string? name = property.Identifier.Text;
+            if (name == null)
+                return;
+
+            LocalisationMember member = localisationFile.Members.Single(m => m.Name == name && m.Parameters.Length == 0);
+
+            if (member.EnglishText == member.XmlDoc)
+                return;
+
+            var creationExpression = (ObjectCreationExpressionSyntax)property.ExpressionBody.Expression;
+            var textArgument = creationExpression.ArgumentList!.Arguments.Last();
+
+            context.ReportDiagnostic(Diagnostic.Create(DiagnosticRules.TEXT_DOES_NOT_MATCH_XMLDOC, textArgument.GetLocation(), property));
+        }
+    }
+}

--- a/LocalisationAnalyser/Analysers/XmlDocDoesNotMatchTextAnalyser.cs
+++ b/LocalisationAnalyser/Analysers/XmlDocDoesNotMatchTextAnalyser.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Immutable;
+using System.Linq;
+using LocalisationAnalyser.Localisation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace LocalisationAnalyser.Analysers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class XmlDocDoesNotMatchTextAnalyser : AbstractMemberAnalyser
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticRules.XMLDOC_DOES_NOT_MATCH_TEXT);
+
+        protected override void AnalyseProperty(SyntaxTreeAnalysisContext context, PropertyDeclarationSyntax property, LocalisationFile localisationFile)
+        {
+            base.AnalyseProperty(context, property, localisationFile);
+
+            string? name = property.Identifier.Text;
+            if (name == null)
+                return;
+
+            LocalisationMember member = localisationFile.Members.Single(m => m.Name == name && m.Parameters.Length == 0);
+
+            if (member.EnglishText == member.XmlDoc)
+                return;
+
+            var xmlDocTrivia = property.Modifiers.First().LeadingTrivia.FirstOrDefault(t => t.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia));
+
+            context.ReportDiagnostic(Diagnostic.Create(DiagnosticRules.XMLDOC_DOES_NOT_MATCH_TEXT, xmlDocTrivia.GetLocation(), property));
+        }
+    }
+}

--- a/LocalisationAnalyser/CodeFixes/AbstractMemberCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/AbstractMemberCodeFixProvider.cs
@@ -17,6 +17,8 @@ namespace LocalisationAnalyser.CodeFixes
 {
     public abstract class AbstractMemberCodeFixProvider : CodeFixProvider
     {
+        public override FixAllProvider? GetFixAllProvider() => null;
+
         protected async Task<Solution> UpdateDefinition(Document document, MemberDeclarationSyntax member, bool preview, CancellationToken cancellationToken)
         {
             LocalisationFile currentFile;

--- a/LocalisationAnalyser/CodeFixes/AbstractMemberCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/AbstractMemberCodeFixProvider.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using LocalisationAnalyser.Localisation;
+using LocalisationAnalyser.Utils;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace LocalisationAnalyser.CodeFixes
+{
+    public abstract class AbstractMemberCodeFixProvider : CodeFixProvider
+    {
+        protected async Task<Solution> UpdateDefinition(Document document, MemberDeclarationSyntax member, bool preview, CancellationToken cancellationToken)
+        {
+            LocalisationFile currentFile;
+
+            using (var ms = new MemoryStream())
+            {
+                using (var sw = new StreamWriter(ms, Encoding.UTF8, 1024, true))
+                    await sw.WriteAsync((await document.GetTextAsync(cancellationToken)).ToString());
+
+                ms.Seek(0, SeekOrigin.Begin);
+
+                currentFile = await LocalisationFile.ReadAsync(ms);
+            }
+
+            LocalisationFile updatedFile = currentFile.WithMembers(currentFile.Members.Select(m =>
+            {
+                if (m.Name != ((PropertyDeclarationSyntax)member).Identifier.Text)
+                    return m;
+
+                return FixMember(m);
+            }).ToArray());
+
+            using (var ms = new MemoryStream())
+            {
+                var options = await document.GetAnalyserOptionsAsync(cancellationToken);
+                await updatedFile.WriteAsync(ms, document.Project.Solution.Workspace, options, true);
+
+                return document.WithText(SourceText.From(ms, Encoding.UTF8)).Project.Solution;
+            }
+        }
+
+        protected abstract LocalisationMember FixMember(LocalisationMember member);
+    }
+}

--- a/LocalisationAnalyser/CodeFixes/MakeTextMatchXmlDocCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/MakeTextMatchXmlDocCodeFixProvider.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using LocalisationAnalyser.Localisation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LocalisationAnalyser.CodeFixes
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    public class MakeTextMatchXmlDocCodeFixProvider : AbstractMemberCodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticRules.TEXT_DOES_NOT_MATCH_XMLDOC.Id);
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+            var member = root!.FindToken(diagnosticSpan.Start).Parent.FirstAncestorOrSelf<MemberDeclarationSyntax>();
+
+            context.RegisterCodeFix(
+                new LocaliseStringCodeAction(
+                    "Update translation text to match XMLDoc",
+                    (preview, cancellationToken) => UpdateDefinition(context.Document, member, preview, cancellationToken),
+                    @"update-text"),
+                diagnostic);
+        }
+
+        protected override LocalisationMember FixMember(LocalisationMember member)
+            => new LocalisationMember(member.Name, member.Key, member.XmlDoc, member.XmlDoc, member.Parameters.ToArray());
+    }
+}

--- a/LocalisationAnalyser/CodeFixes/MakeXmlDocMatchTextCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/MakeXmlDocMatchTextCodeFixProvider.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using LocalisationAnalyser.Localisation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LocalisationAnalyser.CodeFixes
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    public class MakeXmlDocMatchTextCodeFixProvider : AbstractMemberCodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticRules.XMLDOC_DOES_NOT_MATCH_TEXT.Id);
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+            var member = (MemberDeclarationSyntax)root!.FindToken(diagnosticSpan.Start).Parent;
+
+            context.RegisterCodeFix(
+                new LocaliseStringCodeAction(
+                    "Update XMLDoc to match translation text",
+                    (preview, cancellationToken) => UpdateDefinition(context.Document, member, preview, cancellationToken),
+                    @"update-xmldoc"),
+                diagnostic);
+        }
+
+        protected override LocalisationMember FixMember(LocalisationMember member)
+            => new LocalisationMember(member.Name, member.Key, member.EnglishText, member.EnglishText, member.Parameters.ToArray());
+    }
+}

--- a/LocalisationAnalyser/DiagnosticRules.cs
+++ b/LocalisationAnalyser/DiagnosticRules.cs
@@ -20,6 +20,24 @@ namespace LocalisationAnalyser
             true,
             "This string can be localised by using TranslatableString.");
 
+        public static readonly DiagnosticDescriptor XMLDOC_DOES_NOT_MATCH_TEXT = new DiagnosticDescriptor(
+            "OLOC002",
+            "XMLDoc does not match the translation text",
+            "XMLDoc does not match the translation text",
+            "Globalization",
+            DiagnosticSeverity.Warning,
+            true,
+            "Prevent confusion by matching the XMLDoc and the translation text.");
+
+        public static readonly DiagnosticDescriptor TEXT_DOES_NOT_MATCH_XMLDOC = new DiagnosticDescriptor(
+            "OLOC003",
+            "Translation text does not match the XMLDoc",
+            "Translation text does not match the XMLDoc",
+            "Globalization",
+            DiagnosticSeverity.Warning,
+            true,
+            "Prevent confusion by matching the XMLDoc and the translation text.");
+
 #pragma warning restore RS2008
     }
 }


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-localisation-analyser/pull/47

Caveats: Currently only supports properties. Since methods are going to need quite a bit of implementation themselves (I think), I'm going to get this one in as an initial pass.

Resolves the first part of https://github.com/ppy/osu-localisation-analyser/issues/37

https://user-images.githubusercontent.com/1329837/171994625-b001c9cb-2181-496a-979a-192edac01b52.mp4