### PR TITLE
Improve key derivation for sequential capital letters

### DIFF
--- a/LocalisationAnalyser.Tests/CodeFixes/LocaliseClassStringCodeFixProviderTests.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/LocaliseClassStringCodeFixProviderTests.cs
@@ -22,6 +22,7 @@ namespace LocalisationAnalyser.Tests.CodeFixes
         [InlineData("LicenseHeader")]
         [InlineData("DescriptionAttribute")]
         [InlineData("StringWithApostrophe")]
+        [InlineData("SequentialCapitals")]
         public async Task Check(string name) => await RunTest(name);
 
         [Theory]

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/SequentialCapitals/Fixed/Localisation/ProgramStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/SequentialCapitals/Fixed/Localisation/ProgramStrings.txt
@@ -1,0 +1,16 @@
+using osu.Framework.Localisation;
+
+namespace TestProject.Localisation
+{
+    public static class ProgramStrings
+    {
+        private const string prefix = @"TestProject.Localisation.Program";
+
+        /// <summary>
+        /// "Mac OS"
+        /// </summary>
+        public static LocalisableString MacOS => new TranslatableString(getKey(@"mac_os"), @"Mac OS");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/SequentialCapitals/Fixed/Program.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/SequentialCapitals/Fixed/Program.txt
@@ -1,0 +1,12 @@
+using TestProject.Localisation;
+
+namespace Test
+{
+    class Program
+    {
+        static void Main()
+        {
+            string x = ProgramStrings.MacOS;
+        }
+    }
+}

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/SequentialCapitals/Sources/Program.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/SequentialCapitals/Sources/Program.txt
@@ -1,0 +1,10 @@
+namespace Test
+{
+    class Program
+    {
+        static void Main()
+        {
+            string x = [|"Mac OS"|];
+        }
+    }
+}

--- a/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/AbstractLocaliseStringCodeFixProvider.cs
@@ -361,11 +361,14 @@ namespace LocalisationAnalyser.CodeFixes
         {
             var keyBuilder = new StringBuilder();
 
+            bool lastWasCapital = false;
+
             foreach (var c in memberName)
             {
-                if (char.IsUpper(c) && keyBuilder.Length > 0)
+                if (char.IsUpper(c) && keyBuilder.Length > 0 && !lastWasCapital)
                     keyBuilder.Append('_');
                 keyBuilder.Append(char.ToLowerInvariant(c));
+                lastWasCapital = char.IsUpper(c);
             }
 
             return keyBuilder.ToString();


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-localisation-analyser/pull/47

As mentioned in discord, a string like `Mac OS` would turn into `mac_o_s`, which is likely not what was intended by context. This makes it `mac_os` for this case.