### PR TITLE
Resolve build warnings

### DIFF
--- a/LocalisationAnalyser/Localisation/LocalisationFile.cs
+++ b/LocalisationAnalyser/Localisation/LocalisationFile.cs
@@ -4,12 +4,9 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Formatting;
 
 namespace LocalisationAnalyser.Localisation
 {
@@ -53,19 +50,6 @@ namespace LocalisationAnalyser.Localisation
         /// <returns>The resultant <see cref="LocalisationFile"/>.</returns>
         public LocalisationFile WithMembers(params LocalisationMember[] members)
             => new LocalisationFile(Namespace, Name, Prefix, members);
-
-        /// <summary>
-        /// Writes this <see cref="LocalisationFile"/> to a stream.
-        /// </summary>
-        /// <param name="stream">The stream to write to.</param>
-        /// <param name="workspace">The workspace to format with.</param>
-        /// <param name="options">The analyser options to apply to the document.</param>
-        /// <param name="leaveOpen">Whether to leave the given <paramref name="stream"/> open.</param>
-        public async Task WriteAsync(Stream stream, Workspace workspace, AnalyzerConfigOptions? options = null, bool leaveOpen = false)
-        {
-            using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, leaveOpen))
-                await sw.WriteAsync(Formatter.Format(SyntaxGenerators.GenerateClassSyntax(workspace, this, options), workspace).ToFullString());
-        }
 
         /// <summary>
         /// Reads a <see cref="LocalisationFile"/> from a stream.

--- a/LocalisationAnalyser/Localisation/LocalisationFileExtensions.cs
+++ b/LocalisationAnalyser/Localisation/LocalisationFileExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace LocalisationAnalyser.Localisation
+{
+    public static class LocalisationFileExtensions
+    {
+        /// <summary>
+        /// Writes this <see cref="LocalisationFile"/> to a stream.
+        /// </summary>
+        /// <param name="file">The <see cref="LocalisationFile"/> to be written to the stream.</param>
+        /// <param name="stream">The stream to write to.</param>
+        /// <param name="workspace">The workspace to format with.</param>
+        /// <param name="options">The analyser options to apply to the document.</param>
+        /// <param name="leaveOpen">Whether to leave the given <paramref name="stream"/> open.</param>
+        public static async Task WriteAsync(this LocalisationFile file, Stream stream, Workspace workspace, AnalyzerConfigOptions? options = null, bool leaveOpen = false)
+        {
+            using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, leaveOpen))
+                await sw.WriteAsync(Formatter.Format(SyntaxGenerators.GenerateClassSyntax(workspace, file, options), workspace).ToFullString());
+        }
+    }
+}

--- a/LocalisationAnalyser/Localisation/LocalisationFile_Walker.cs
+++ b/LocalisationAnalyser/Localisation/LocalisationFile_Walker.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Web;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -104,7 +105,20 @@ namespace LocalisationAnalyser.Localisation
                     }
                 }
 
-                currentXmlDoc = SyntaxGenerators.DecodeXmlDoc(sb.ToString());
+                currentXmlDoc = decodeXmlDoc(sb.ToString());
+            }
+
+            private static string decodeXmlDoc(string xmlDoc)
+            {
+                xmlDoc = xmlDoc.Trim();
+
+                // A valid XMLDoc is formulated as: "text". We need to remove only one set of quotes from either side, so Trim() is too greedy.
+                if (xmlDoc.Length > 0)
+                    xmlDoc = xmlDoc.Substring(1);
+                if (xmlDoc.Length > 0)
+                    xmlDoc = xmlDoc.Substring(0, xmlDoc.Length - 1);
+
+                return HttpUtility.HtmlDecode(xmlDoc);
             }
 
             private static string convertNamespaceToString(NamespaceDeclarationSyntax declaration)

--- a/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
+++ b/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
@@ -226,19 +226,6 @@ namespace LocalisationAnalyser.Localisation
             return string.Join(Environment.NewLine, lines);
         }
 
-        public static string DecodeXmlDoc(string xmlDoc)
-        {
-            xmlDoc = xmlDoc.Trim();
-
-            // A valid XMLDoc is formulated as: "text". We need to remove only one set of quotes from either side, so Trim() is too greedy.
-            if (xmlDoc.Length > 0)
-                xmlDoc = xmlDoc.Substring(1);
-            if (xmlDoc.Length > 0)
-                xmlDoc = xmlDoc.Substring(0, xmlDoc.Length - 1);
-
-            return HttpUtility.HtmlDecode(xmlDoc);
-        }
-
         /// <summary>
         /// Converts a string literal to its verbatim representation. Assumes that the string is already non-verbatim.
         /// </summary>


### PR DESCRIPTION
By splitting out references to `SyntaxGenerators`.