### PR TITLE
Improve VSCode compatibility

### DIFF
--- a/LocalisationAnalyser.Tests/CodeFixes/Providers/LocaliseClassStringCodeFixMockProvider.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/Providers/LocaliseClassStringCodeFixMockProvider.cs
@@ -12,5 +12,7 @@ namespace LocalisationAnalyser.Tests.CodeFixes.Providers
             : base(new MockFileSystem())
         {
         }
+
+        protected override bool AddFilesToWorkspace => true;
     }
 }

--- a/LocalisationAnalyser.Tests/CodeFixes/Providers/LocaliseCommonStringCodeFixMockProvider.cs
+++ b/LocalisationAnalyser.Tests/CodeFixes/Providers/LocaliseCommonStringCodeFixMockProvider.cs
@@ -12,5 +12,7 @@ namespace LocalisationAnalyser.Tests.CodeFixes.Providers
             : base(new MockFileSystem())
         {
         }
+
+        protected override bool AddFilesToWorkspace => true;
     }
 }

--- a/LocalisationAnalyser/Localisation/LocalisationFile_Walker.cs
+++ b/LocalisationAnalyser/Localisation/LocalisationFile_Walker.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
-using System.Web;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -154,7 +154,7 @@ namespace LocalisationAnalyser.Localisation
                 if (xmlDoc.Length > 0)
                     xmlDoc = xmlDoc.Substring(0, xmlDoc.Length - 1);
 
-                return HttpUtility.HtmlDecode(xmlDoc);
+                return WebUtility.HtmlDecode(xmlDoc);
             }
 
             private static string convertNamespaceToString(NamespaceDeclarationSyntax declaration)

--- a/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
+++ b/LocalisationAnalyser/Localisation/SyntaxGenerators.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
-using System.Web;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -215,7 +215,7 @@ namespace LocalisationAnalyser.Localisation
                 if (i == 0)
                     sb.Append("\"");
 
-                sb.Append(HttpUtility.HtmlEncode(lines[i]));
+                sb.Append(WebUtility.HtmlEncode(lines[i]));
 
                 if (i == lines.Length - 1)
                     sb.Append("\"");


### PR DESCRIPTION
Two issues fixed here.
1. VSCode would throw an exception saying something along the lines of `Namespace System.Web can't be found in netstandard`. Working around this by referencing `System.Net` instead, which is in CoreCLR itself and thus should always work.
2. VSCode would duplicate file contents into the file and just generally act... weird. It was due to adding files via the workspace (see inline comment).