### PR TITLE
Add localisation support for multiple namespace levels

### DIFF
--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -85,7 +85,7 @@ namespace LocalisationAnalyser.Tools
 
             foreach (var file in localisationFiles)
             {
-                Console.WriteLine($"Processing {file.Name} {(file.Folders.Count > 1 ? $"(sub-namespace \"{string.Join('/', file.Folders)}\")" : string.Empty)}...");
+                Console.WriteLine($"Processing {file.Name}...");
 
                 LocalisationFile localisationFile;
                 using (var stream = File.OpenRead(file.FilePath))


### PR DESCRIPTION
Closes #53 (kinda?)

Previously discussed on [Discord](https://discord.com/channels/188630481301012481/188630652340404224/1070954126915145749)

I noticed after two localisation update PRs on https://github.com/ppy/osu-resources that some strings from https://github.com/ppy/osu/pull/22489 weren't included.
Based on the above Discord discussion, I thought that the analyser would support that automatically, but turns out it does not.