### PR TITLE
fix: remove duplicate path separator

### DIFF
--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -93,7 +93,7 @@ namespace LocalisationAnalyser.Tools
 
                 string targetDirectory = output != null ? output.FullName : Path.GetDirectoryName(file.FilePath)!;
                 if (file.Folders.Count > 1)
-                    targetDirectory += Path.DirectorySeparatorChar + string.Join(Path.DirectorySeparatorChar, file.Folders.Skip(1));
+                    targetDirectory += string.Join(Path.DirectorySeparatorChar, file.Folders.Skip(1));
 
                 string targetFileName = localisationFile.Prefix[(localisationFile.Prefix.LastIndexOf('.') + 1)..];
                 string resxFile = Path.Combine(targetDirectory, $"{targetFileName}.resx");

--- a/LocalisationAnalyser.Tools/Program.cs
+++ b/LocalisationAnalyser.Tools/Program.cs
@@ -92,8 +92,12 @@ namespace LocalisationAnalyser.Tools
                     localisationFile = await LocalisationFile.ReadAsync(stream);
 
                 string targetDirectory = output != null ? output.FullName : Path.GetDirectoryName(file.FilePath)!;
+
                 if (file.Folders.Count > 1)
-                    targetDirectory += string.Join(Path.DirectorySeparatorChar, file.Folders.Skip(1));
+                {
+                    string subNamespaceDirectory = Path.Join(file.Folders.Skip(1).ToArray());
+                    targetDirectory = Path.Join(targetDirectory, subNamespaceDirectory);
+                }
 
                 string targetFileName = localisationFile.Prefix[(localisationFile.Prefix.LastIndexOf('.') + 1)..];
                 string resxFile = Path.Combine(targetDirectory, $"{targetFileName}.resx");


### PR DESCRIPTION
For localisation in sub-namespaces. I was going to PR on https://github.com/ppy/osu a bump for in `.config/dotnet-tools.json` when I noticed this while comparing behaviour before and after bumping.

Despite not breaking anything on Windows, I haven't tested if it breaks on macOS or Linux. Better be safe than sorry.
This was probably an oversight during my testing for #57.
Will probably need more testing on other platforms to see if it behaves correctly.