### PR TITLE
Add method xmldoc analyser + codefix support

### DIFF
--- a/LocalisationAnalyser.Tests/Resources/Analysers/TextDoesNotMatchXmlDoc/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/Analysers/TextDoesNotMatchXmlDoc/Localisation/CommonStrings.txt
@@ -26,6 +26,16 @@ namespace TestProject.Localisation
         /// </summary>
         public static LocalisableString SpecialCharsDoNotMatch => new TranslatableString(getKey(@"special_chars"), [|@"<>?""''&*!@#&*^%^()-="|]);
 
+        /// <summary>
+        /// "matches {0}"
+        /// </summary>
+        public static LocalisableString MethodMatches(string arg0) => new TranslatableString(getKey(@"method_matches"), @"matches {0}", arg0);
+
+        /// <summary>
+        /// "does not match {0}"
+        /// </summary>
+        public static LocalisableString MethodDoesNotMatch(string arg0) => new TranslatableString(getKey(@"method_does_not_match"), [|@"dnm {0}"|], arg0);
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/LocalisationAnalyser.Tests/Resources/Analysers/XmlDocDoesNotMatchText/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/Analysers/XmlDocDoesNotMatchText/Localisation/CommonStrings.txt
@@ -26,6 +26,16 @@ namespace TestProject.Localisation
         /// </summary>
 |]        public static LocalisableString SpecialCharsDoNotMatch => new TranslatableString(getKey(@"special_chars"), @"<>?""''&*!@#&*^%^()-=");
 
+        /// <summary>
+        /// "matches {0}"
+        /// </summary>
+        public static LocalisableString MethodMatches(string arg0) => new TranslatableString(getKey(@"method_matches"), @"matches {0}", arg0);
+
+        ///[| <summary>
+        /// "does not match {0}"
+        /// </summary>
+|]        public static LocalisableString MethodDoesNotMatch(string arg0) => new TranslatableString(getKey(@"method_does_not_match"), @"dnm {0}", arg0);
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeTextMatchXmlDoc/Fixed/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeTextMatchXmlDoc/Fixed/Localisation/CommonStrings.txt
@@ -11,6 +11,11 @@ namespace TestProject.Localisation
         /// </summary>
         public static LocalisableString DoesNotMatch => new TranslatableString(getKey(@"does_not_match"), @"does not match");
 
+        /// <summary>
+        /// "method does not match {0}"
+        /// </summary>
+        public static LocalisableString MethodDoesNotMatch(string arg0) => new TranslatableString(getKey(@"method_does_not_match"), @"method does not match {0}", arg0);
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeTextMatchXmlDoc/Sources/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeTextMatchXmlDoc/Sources/Localisation/CommonStrings.txt
@@ -11,6 +11,11 @@ namespace TestProject.Localisation
         /// </summary>
         public static LocalisableString DoesNotMatch => new TranslatableString(getKey(@"does_not_match"), [|@"dnm"|]);
 
+        /// <summary>
+        /// "method does not match {0}"
+        /// </summary>
+        public static LocalisableString MethodDoesNotMatch(string arg0) => new TranslatableString(getKey(@"method_does_not_match"), [|@"dnm"|], arg0);
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeXmlDocMatchText/Fixed/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeXmlDocMatchText/Fixed/Localisation/CommonStrings.txt
@@ -11,6 +11,11 @@ namespace TestProject.Localisation
         /// </summary>
         public static LocalisableString DoesNotMatch => new TranslatableString(getKey(@"does_not_match"), @"dnm");
 
+        /// <summary>
+        /// "dnm {0}"
+        /// </summary>
+        public static LocalisableString MethodDoesNotMatch(string arg0) => new TranslatableString(getKey(@"method_does_not_match"), @"dnm {0}", arg0);
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeXmlDocMatchText/Sources/Localisation/CommonStrings.txt
+++ b/LocalisationAnalyser.Tests/Resources/CodeFixes/MakeXmlDocMatchText/Sources/Localisation/CommonStrings.txt
@@ -11,6 +11,11 @@ namespace TestProject.Localisation
         /// </summary>
 |]        public static LocalisableString DoesNotMatch => new TranslatableString(getKey(@"does_not_match"), @"dnm");
 
+        ///[| <summary>
+        /// "method does not match"
+        /// </summary>
+|]        public static LocalisableString MethodDoesNotMatch(string arg0) => new TranslatableString(getKey(@"method_does_not_match"), @"dnm {0}", arg0);
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/LocalisationAnalyser/Analysers/AbstractMemberAnalyser.cs
+++ b/LocalisationAnalyser/Analysers/AbstractMemberAnalyser.cs
@@ -30,8 +30,15 @@ namespace LocalisationAnalyser.Analysers
 
             var root = context.Tree.GetRoot();
 
-            foreach (var prop in root.DescendantNodes().OfType<PropertyDeclarationSyntax>())
-                AnalyseProperty(context, prop, file);
+            foreach (var property in root.DescendantNodes().OfType<PropertyDeclarationSyntax>())
+                AnalyseProperty(context, property, file);
+
+            foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+                AnalyseMethod(context, method, file);
+        }
+
+        protected virtual void AnalyseMethod(SyntaxTreeAnalysisContext context, MethodDeclarationSyntax method, LocalisationFile localisationFile)
+        {
         }
 
         protected virtual void AnalyseProperty(SyntaxTreeAnalysisContext context, PropertyDeclarationSyntax property, LocalisationFile localisationFile)

--- a/LocalisationAnalyser/CodeFixes/AbstractMemberCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/AbstractMemberCodeFixProvider.cs
@@ -35,7 +35,14 @@ namespace LocalisationAnalyser.CodeFixes
 
             LocalisationFile updatedFile = currentFile.WithMembers(currentFile.Members.Select(m =>
             {
-                if (m.Name != ((PropertyDeclarationSyntax)member).Identifier.Text)
+                string? identifier = member switch
+                {
+                    PropertyDeclarationSyntax property => property.Identifier.Text,
+                    MethodDeclarationSyntax method => method.Identifier.Text,
+                    _ => null
+                };
+
+                if (m.Name != identifier)
                     return m;
 
                 return FixMember(m);


### PR DESCRIPTION
I'd say this pretty much closes https://github.com/ppy/osu-localisation-analyser/issues/37

It won't correctly handle cases where the arg is replaced, e.g. `"some text {wangs}"` will transfer across literally without fixing the arg to `{0}`, but it handles the most simple missed cases.

https://github.com/ppy/osu-localisation-analyser/assets/1329837/3ce1cc61-47d0-462c-b1ad-01e3e1a9895f
